### PR TITLE
Feature/add lishid suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,21 +35,31 @@ Obsidian Notion-Like Tables allows you to create markdown tables using an interf
 
 ### Making a Table via Command
 
-To quickly make a table you can use the add table command. Press `CMD-P` on your keyboard search "Add table".
+To quickly make a table you can use the add table command. Press `cmd + p` on your keyboard search "Add table".
 
-Note: you must be in editing mode for this command to appear
+Note: you must be in editing mode for this command to appear.
 
-Toggle to preview mode and the table will automatically render.
+Toggle to reading mode and the table will automatically render.
 
 ### Making a Table Manually
 
-Make a table manually using normal markdown syntax. Under the hyphen row, specify the types of each column.
+A Notion-Like Table uses normal Obsidian table markdown syntax with 2 additional rows:
 
-The plugin currently supports 3 cell types: `text`, `number`, and `tag`.
+-   A table id row
+-   A type definition row
+
+#### Table ID Row
+
+The table id row is a normal markdown row with the first column containing a unique string. This string must be unique per table per file. If you use the same id in another file that's fine. The id is used to map a table to its data in the settings. If you change this id, your table will not be able to find its settings and will create new ones. If you omit this id, your table will not be rendered as an NLT table.
+
+Example row:
+| my-table-id | | |
+
+##### Type Definition Row
+
+The type definition row is a normal markdown row with each column defining the type of data you want that column to accept. The plugin currently supports 3 column types: `text`, `number` and `tag`.
 
 ![Screenshot](.readme/markdown.png)
-
-Toggle to preview mode and the table will automatically render.
 
 ### Editing Cells
 
@@ -76,11 +86,6 @@ A cell type error will occur if you enter data which doesn't match the column da
 
 ![Screenshot](.readme/cell-error-1.png)
 ![Screenshot](.readme/cell-error-2.png)
-
-### Live Preview
-
-April 9, 2022:
-Tables display with live preview is still being developed in Obsidian. If you're using live preview, please always use the table in "Reading" mode not "Editing" mode.
 
 ### Theming
 

--- a/main.ts
+++ b/main.ts
@@ -15,7 +15,6 @@ export default class NltPlugin extends Plugin {
 		await this.forcePostProcessorReload();
 
 		this.registerMarkdownPostProcessor((element, context) => {
-			console.log(context);
 			const table = element.getElementsByTagName("table");
 			if (table.length === 1) {
 				context.addChild(

--- a/main.ts
+++ b/main.ts
@@ -2,15 +2,7 @@ import { Plugin, Editor, MarkdownView } from "obsidian";
 
 import { NLTTable } from "src/NLTTable";
 import { NltSettings, DEFAULT_SETTINGS } from "src/app/services/state";
-import { Header } from "src/app/services/state";
-import {
-	findMarkdownTablesFromFileData,
-	parseTableFromMarkdown,
-	validTypeDefinitionRow,
-	findAppData,
-	hashParsedTable,
-	mergeAppData,
-} from "src/app/services/utils";
+import { createEmptyTable, randomTableId } from "src/app/services/utils";
 export default class NltPlugin extends Plugin {
 	settings: NltSettings;
 
@@ -23,6 +15,7 @@ export default class NltPlugin extends Plugin {
 		await this.forcePostProcessorReload();
 
 		this.registerMarkdownPostProcessor((element, context) => {
+			console.log(context);
 			const table = element.getElementsByTagName("table");
 			if (table.length === 1) {
 				context.addChild(
@@ -42,8 +35,8 @@ export default class NltPlugin extends Plugin {
 
 	registerFileHandlers() {
 		//Our persisted data uses a key of the file path and then stores an object mapping
-		//to a CRC32 key and an AppData object
-		//If the file we have data for changes, we want to update our cache
+		//to a table id and an AppData object.
+		//If the file path changes, we want to update our cache so that the data is still accessible.
 		this.registerEvent(
 			this.app.vault.on("rename", (file, oldPath) => {
 				if (this.settings.appData[oldPath]) {
@@ -55,68 +48,6 @@ export default class NltPlugin extends Plugin {
 				}
 			})
 		);
-
-		//The loadAppData and saveAppData functions handle markdown editing caused from the app.
-		//However if a user updates the source markdown of a table and a cached version already existed,
-		//since the CRC32 value is different, it will recreate brand new app data. This will cause things
-		//like the tag colors to change.
-		//We can avoid this by handling editor changes. If a file that was edited contains a table
-		//and that table has a reference in the cache, then we should update it with new data.
-		this.registerEvent(
-			this.app.workspace.on("editor-change", async (editor) => {
-				console.log("EDITOR CHANGE!");
-				const file = this.app.workspace.getActiveFile();
-				const markdownTables = findMarkdownTablesFromFileData(
-					editor.getValue()
-				);
-				if (markdownTables.length !== 0) {
-					markdownTables.forEach((markdownTable) => {
-						const parsedTable =
-							parseTableFromMarkdown(markdownTable);
-						//Validate table
-						if (!validTypeDefinitionRow(parsedTable)) return;
-
-						const headers = parsedTable[0];
-
-						//Get the saved entry
-						if (this.settings.appData[file.path]) {
-							const savedData = this.settings.appData[file.path];
-							//Check headers of the save data
-							Object.entries(savedData).forEach((entry) => {
-								const [key, value] = entry;
-								//If the headers match, update the data and the CRC
-								if (
-									value.headers.every((header: Header) =>
-										headers.includes(header.content)
-									)
-								) {
-									const hash = hashParsedTable(parsedTable);
-
-									//If you change something in reading mode, we will persist
-									//that data in the settings cache. However, if you go back
-									//to editing mode, the editor-change callback will be ran.
-									//Since the hashes are the same, no data has updated, so we
-									//don't need to do anything
-									if (parseInt(key) === hash) return;
-
-									const newAppData = findAppData(parsedTable);
-									const merged = mergeAppData(
-										this.settings.appData[file.path][key],
-										newAppData
-									);
-									this.settings.appData[file.path][hash] =
-										merged;
-									delete this.settings.appData[file.path][
-										key
-									];
-									this.saveSettings();
-								}
-							});
-						}
-					});
-				}
-			})
-		);
 	}
 
 	registerCommands() {
@@ -124,24 +55,9 @@ export default class NltPlugin extends Plugin {
 			id: "nlt-add-table",
 			name: "Add table",
 			editorCallback: (editor: Editor) => {
-				editor.replaceSelection(this.emptyTable());
+				editor.replaceSelection(createEmptyTable(randomTableId()));
 			},
 		});
-	}
-
-	/**
-	 * Creates a 1 column NLT markdown table
-	 * @returns An NLT markdown table
-	 */
-	emptyTable(): string {
-		const columnName = "Column 1";
-		const rows = [];
-		rows[0] = `|  ${columnName}  |`;
-		rows[1] = `|  ${Array(columnName.length).fill("-").join("")}  |`;
-		rows[2] = `|  text ${Array(columnName.length - 3)
-			.fill(" ")
-			.join("")}  |`;
-		return rows.join("\n");
 	}
 
 	async loadSettings() {

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, Editor } from "obsidian";
+import { Plugin, Editor, MarkdownView } from "obsidian";
 
 import { NLTTable } from "src/NLTTable";
 import { NltSettings, DEFAULT_SETTINGS } from "src/app/services/state";
@@ -163,20 +163,18 @@ export default class NltPlugin extends Plugin {
 		await this.forcePostProcessorReload();
 	}
 
-	/**
+	/*
 	 * Forces the post processor to be called again.
 	 * This is necessary for clean up purposes on unload and causing NLT tables
 	 * to be rendered onload.
 	 */
 	async forcePostProcessorReload() {
-		const leaves = [
-			...this.app.workspace.getLeavesOfType("markdown"),
-			...this.app.workspace.getLeavesOfType("edit"),
-		];
-		for (let i = 0; i < leaves.length; i++) {
-			const leaf = leaves[i];
-			this.app.workspace.duplicateLeaf(leaf);
-			leaf.detach();
-		}
+		this.app.workspace.iterateAllLeaves((leaf) => {
+			const view = leaf.view;
+			if (view.getViewType() === "markdown") {
+				if (view instanceof MarkdownView)
+					view.previewMode.rerender(true);
+			}
+		});
 	}
 }

--- a/main.ts
+++ b/main.ts
@@ -64,6 +64,7 @@ export default class NltPlugin extends Plugin {
 		//and that table has a reference in the cache, then we should update it with new data.
 		this.registerEvent(
 			this.app.workspace.on("editor-change", async (editor) => {
+				console.log("EDITOR CHANGE!");
 				const file = this.app.workspace.getActiveFile();
 				const markdownTables = findMarkdownTablesFromFileData(
 					editor.getValue()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "obsidian-notion-like-tables",
-  "version": "0.3.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-notion-like-tables",
-      "version": "0.3.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@mui/icons-material": "^5.5.0",
-        "crc-32": "^1.2.2",
         "html-react-parser": "^1.4.9",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -6246,17 +6245,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -21536,11 +21524,6 @@
         "path-type": "^4.0.0",
         "yaml": "^1.7.2"
       }
-    },
-    "crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@mui/icons-material": "^5.5.0",
-    "crc-32": "^1.2.2",
     "html-react-parser": "^1.4.9",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/NLTTable.tsx
+++ b/src/NLTTable.tsx
@@ -32,6 +32,7 @@ export class NLTTable extends MarkdownRenderChild {
 
 	async onload() {
 		const { tableId, data } = loadAppData(
+			this.plugin,
 			this.settings,
 			this.containerEl,
 			this.sourcePath

--- a/src/NLTTable.tsx
+++ b/src/NLTTable.tsx
@@ -31,9 +31,7 @@ export class NLTTable extends MarkdownRenderChild {
 	}
 
 	async onload() {
-		const data = loadAppData(
-			this.plugin,
-			this.app,
+		const { tableId, data } = loadAppData(
 			this.settings,
 			this.containerEl,
 			this.sourcePath
@@ -50,6 +48,7 @@ export class NLTTable extends MarkdownRenderChild {
 						settings={this.settings}
 						data={data}
 						sourcePath={this.sourcePath}
+						tableId={tableId}
 					/>
 				</AppContext.Provider>,
 				this.el

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -47,6 +47,19 @@ export default function App({
 	const app = useApp();
 
 	useEffect(() => {
+		//Sort on first render
+		//Use case:
+		//If a user deletes or adds a new row (by copying and pasting, for example)
+		//then we want to make sure that value is sorted in
+
+		for (let i = 0; i < appData.headers.length; i++) {
+			const header = appData.headers[i];
+			if (header.sortName !== SORT.DEFAULT.name)
+				sortRows(header.index, header.type, header.sortName, false);
+		}
+	}, []);
+
+	useEffect(() => {
 		async function handleUpdate() {
 			//If we're running in Obsidian
 			if (app) {
@@ -246,7 +259,8 @@ export default function App({
 	function sortRows(
 		headerIndex: number,
 		headerType: string,
-		sortName: string
+		sortName: string,
+		shouldUpdate = true
 	) {
 		setAppData((prevState) => {
 			//Create a new array because the sort function mutates
@@ -293,7 +307,7 @@ export default function App({
 			return {
 				...prevState,
 				rows: arr,
-				updateTime: Date.now(),
+				updateTime: shouldUpdate ? Date.now() : 0,
 			};
 		});
 	}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -30,9 +30,16 @@ interface Props {
 	settings: NltSettings;
 	data: AppData;
 	sourcePath: string;
+	tableId: string;
 }
 
-export default function App({ plugin, settings, data, sourcePath }: Props) {
+export default function App({
+	plugin,
+	settings,
+	data,
+	sourcePath,
+	tableId,
+}: Props) {
 	const [oldAppData] = useState<AppData>(data);
 	const [appData, setAppData] = useState<AppData>(data);
 	const appRef = useRef<HTMLInputElement>();
@@ -51,7 +58,8 @@ export default function App({ plugin, settings, data, sourcePath }: Props) {
 							app,
 							oldAppData,
 							appData,
-							sourcePath
+							sourcePath,
+							tableId
 						);
 					} catch (err) {
 						console.log(err);

--- a/src/app/components/EditableTd/index.tsx
+++ b/src/app/components/EditableTd/index.tsx
@@ -108,20 +108,26 @@ export default function EditableTd({
 	}
 
 	function handleOutsideClick() {
-		switch (type) {
-			case CELL_TYPE.TEXT:
-				onUpdateContent(cellId, inputText);
-				setInputText("");
-				break;
-			case CELL_TYPE.NUMBER:
-				onUpdateContent(cellId, inputText);
-				setInputText("");
-				break;
-			case CELL_TYPE.TAG:
-				setInputText("");
-				break;
-			default:
-				break;
+		//If we're in Live Preview mode and we click on the header and then click on the outside of
+		//the component, the header will close, set the data (which didn't change), which cause an update
+		//which persists the data again. We can prevent this by only calling onOutsideClick
+		//if the data has actually changed
+		if (inputText !== content) {
+			switch (type) {
+				case CELL_TYPE.TEXT:
+					onUpdateContent(cellId, inputText);
+					setInputText("");
+					break;
+				case CELL_TYPE.NUMBER:
+					onUpdateContent(cellId, inputText);
+					setInputText("");
+					break;
+				case CELL_TYPE.TAG:
+					setInputText("");
+					break;
+				default:
+					break;
+			}
 		}
 		setCellMenu(initialCellMenuState);
 	}

--- a/src/app/components/HeaderMenu/index.tsx
+++ b/src/app/components/HeaderMenu/index.tsx
@@ -100,7 +100,11 @@ export default function HeaderMenu({
 	}
 
 	function handleOutsideClick(id: string, text: string) {
-		onOutsideClick(id, text);
+		//If we're in Live Preview mode and we click on the header and then click on the outside of
+		//the component, the header will close, set the data (which didn't change), which cause an update
+		//which persists the data again. We can prevent this by only calling onOutsideClick
+		//if the data has actually changed
+		if (text !== content) onOutsideClick(id, text);
 		onClose();
 	}
 

--- a/src/app/components/TagMenuContent/index.tsx
+++ b/src/app/components/TagMenuContent/index.tsx
@@ -37,7 +37,13 @@ export default function TagMenuContent({
 
 	function handleKeyDown(e: React.KeyboardEvent) {
 		if (e.key === "Enter") {
-			onAddTag(inputText);
+			//If this tag content already exists then we will select that tag, otherwise add a new one
+			const tag = tags.filter((tag) => tag.content === inputText)[0];
+			if (tag) {
+				onTagClick(tag.id);
+			} else {
+				onAddTag(inputText);
+			}
 		}
 	}
 

--- a/src/app/services/dataUtils/index.tsx
+++ b/src/app/services/dataUtils/index.tsx
@@ -96,7 +96,7 @@ export const saveAppData = async (
 	const newData = appDataToString(newAppData);
 	try {
 		const file = app.workspace.getActiveFile();
-		let content = await app.vault.read(file);
+		let content = await app.vault.cachedRead(file);
 
 		content = content.replace(
 			findTableRegex(oldAppData.headers, oldAppData.rows),

--- a/src/app/services/dataUtils/index.tsx
+++ b/src/app/services/dataUtils/index.tsx
@@ -108,7 +108,7 @@ export const saveAppData = async (
 		persistAppData(plugin, settings, newAppData, sourcePath);
 
 		//Save the open file with the new table data
-		app.vault.modify(file, content);
+		await app.vault.modify(file, content);
 	} catch (err) {
 		console.log(err);
 	}

--- a/src/app/services/dataUtils/index.tsx
+++ b/src/app/services/dataUtils/index.tsx
@@ -9,6 +9,7 @@ import {
 	parseTableFromEl,
 	validTypeDefinitionRow,
 	findTableId,
+	mergeAppData,
 } from "../../services/utils";
 
 import { DEBUG } from "../../constants";
@@ -26,12 +27,16 @@ interface LoadedData {
  * @returns AppData - The loaded data which the app will use to initialize its state
  */
 export const loadAppData = (
+	plugin: NltPlugin,
 	settings: NltSettings,
 	el: HTMLElement,
 	sourcePath: string
 ): LoadedData | null => {
 	const parsedTable = parseTableFromEl(el);
-	console.log(parsedTable);
+	if (DEBUG) {
+		console.log("PARSING TABLE FROM ELEMENT");
+		console.log(parsedTable);
+	}
 
 	const tableId = findTableId(parsedTable);
 	if (!tableId) return null;
@@ -39,32 +44,19 @@ export const loadAppData = (
 
 	if (DEBUG) {
 		console.log("FOUND TABLE ID", tableId);
-		console.log("LOADING DATA");
 	}
 
 	if (settings.appData[sourcePath]) {
 		if (settings.appData[sourcePath][tableId]) {
 			if (DEBUG) console.log("LOADING OLD DATA");
 
-			//TODO merge new data with old data
-			// const newAppData =
-			// 	findAppData(parsedTable);
-			// const merged = mergeAppData(
-			// 	this.settings.appData[file.path][
-			// 		key
-			// 	],
-			// 	newAppData
-			// );
-			// this.settings.appData[file.path][hash] =
-			// 	merged;
-			// delete this.settings.appData[file.path][
-			// 	key
-			// ];
-			// console.log(
-			// 	"REPLACING OLD DATA WITH NEW DATA"
-			// );
-			// console.log(newAppData.updateTime);
-			// this.saveSettings();
+			const newAppData = findAppData(parsedTable);
+			const merged = mergeAppData(
+				settings.appData[sourcePath][tableId],
+				newAppData
+			);
+			settings.appData[sourcePath][tableId] = merged;
+			plugin.saveSettings();
 			return { tableId, data: settings.appData[sourcePath][tableId] };
 		}
 	}

--- a/src/app/services/dataUtils/index.tsx
+++ b/src/app/services/dataUtils/index.tsx
@@ -1,6 +1,5 @@
 import { App, TFile } from "obsidian";
 import { NltSettings } from "../../services/state";
-import crc32 from "crc-32";
 
 import { AppData } from "../../services/state";
 import {
@@ -30,24 +29,24 @@ export const loadAppData = (
 ): AppData | null => {
 	const parsedTable = parseTableFromEl(el);
 	const hash = hashParsedTable(parsedTable);
+	// console.log("LOADING DATA");
+	// console.log(parsedTable);
+	// console.log(hash);
 
 	if (settings.appData[sourcePath]) {
 		//Just in time garbage collection for old tables
 		garbageCollect(plugin, app, settings, sourcePath);
-		if (settings.appData[sourcePath][hash])
+		if (settings.appData[sourcePath][hash]) {
+			// console.log("LOADING OLD DATA", hash);
 			return settings.appData[sourcePath][hash];
+		}
 	}
 
 	//If we don't have a type definition row return null
 	if (!validTypeDefinitionRow(parsedTable)) return null;
 
-	let data = findAppData(parsedTable);
-	//When we find the data, save it in the cache immediately
-	//USE CASE:
-	//if a user makes a table with tags but never edits it
-	//they can open and close the app and the tags will change colors
-	persistAppData(plugin, settings, data, sourcePath);
-	return data;
+	// console.log("LOADING NEW DATA");
+	return findAppData(parsedTable);
 };
 
 const garbageCollect = async (
@@ -71,8 +70,10 @@ const persistAppData = (
 	sourcePath: string
 ) => {
 	const markdownTable = appDataToString(appData);
+	//console.log(markdownTable);
 	const hash = hashMarkdownTable(markdownTable);
 	if (!settings.appData[sourcePath]) settings.appData[sourcePath] = {};
+	// console.log("PERSISTING APP DATA", hash);
 	settings.appData[sourcePath][hash] = appData;
 	plugin.saveData(settings);
 };

--- a/src/app/services/state/index.ts
+++ b/src/app/services/state/index.ts
@@ -19,7 +19,7 @@ export const instanceOfErrorData = (object: any): object is ErrorData => {
 	return "columnIds" in object;
 };
 export interface NltSettings {
-	appData: { [filePath: string]: { [hash: number]: AppData } };
+	appData: { [filePath: string]: { [tableId: string]: AppData } };
 }
 
 export const DEFAULT_SETTINGS: NltSettings = {

--- a/src/app/services/utils/index.test.js
+++ b/src/app/services/utils/index.test.js
@@ -84,7 +84,7 @@ describe("hashMarkdownTable", () => {
 		const parsedTable = [
 			["Column 1", "Column 2"],
 			["text", "text"],
-			["some text", "some more text"],
+			["some text", "some more text, with comma"],
 		];
 		const appData = findAppData(parsedTable);
 		const markdownTable = appDataToString(appData);

--- a/src/app/services/utils/index.test.js
+++ b/src/app/services/utils/index.test.js
@@ -327,6 +327,52 @@ describe("mergeAppData", () => {
 			newAppData.rows[1].creationTime
 		);
 	});
+
+	it("merges table with row removed from bottom", () => {
+		const oldAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["text", "text"],
+			["test 1", "test 2"],
+			["test 3", "test 4"],
+		]);
+		const newAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["text", "text"],
+			["test 3", "test 4"],
+		]);
+
+		const merged = mergeAppData(oldAppData, newAppData);
+		expect(merged.rows[0].creationTime).toEqual(
+			oldAppData.rows[0].creationTime
+		);
+	});
+
+	it("merges table with row added to bottom", () => {
+		const oldAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["text", "text"],
+			["test 1", "test 2"],
+		]);
+		const newAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["text", "text"],
+			["test 1", "test 2"],
+			["test 3", "test 4"],
+		]);
+
+		const merged = mergeAppData(oldAppData, newAppData);
+		//Check content
+		expect(merged.rows[0].creationTime).toEqual(
+			oldAppData.rows[0].creationTime
+		);
+		expect(merged.rows[1].creationTime).toEqual(
+			newAppData.rows[1].creationTime
+		);
+	});
 });
 
 describe("findAppData", () => {

--- a/src/app/services/utils/index.test.js
+++ b/src/app/services/utils/index.test.js
@@ -19,177 +19,290 @@ import {
 	parseTableFromMarkdown,
 	markdownHyphenCellRegex,
 	isMarkdownTable,
-	hashParsedTable,
 	mergeAppData,
-	hashMarkdownTable,
-	appDataToString,
 	parseURLs,
 	parseFileLinks,
-	pruneSettingsCache,
+	findTableId,
+	createEmptyTable,
+	randomTableId,
+	findTableRegex,
+	appDataToMarkdown,
+	calcColumnCharLengths,
+	AppDataStringBuffer,
 } from "./index";
 
 import { CELL_TYPE } from "../../constants";
 import { mockTable } from "../mockData";
 
-describe("pruneSettingsCache", () => {
-	it("keeps hashes that are found in the file", () => {
-		const parsedTable = [
+describe("appDataToMarkdown", () => {
+	it("", () => {
+		const tableId = "123456";
+		const table = [
 			["Column 1", "Column 2"],
+			[tableId, ""],
 			["text", "text"],
 			["some text", "some more text"],
 		];
-		const appData = findAppData(parsedTable);
-		const markdownTable = appDataToString(appData);
-		const fileData = `test ${markdownTable} test`;
-		const hash = hashMarkdownTable(markdownTable);
-		const sourcePath = "test";
-
-		const settings = { appData: { [sourcePath]: { [hash]: appData } } };
-		const newSettings = pruneSettingsCache(settings, sourcePath, fileData);
-		expect(newSettings.appData[sourcePath][hash]).toEqual(appData);
-	});
-
-	it("removes hash that doesn't exist", () => {
-		const parsedTable = [
-			["Column 1", "Column 2"],
-			["text", "text"],
-			["some text", "some more text"],
-		];
-		const appData = findAppData(parsedTable);
-		const markdownTable = appDataToString(appData);
-		const fileData = `test ${markdownTable} test`;
-		const sourcePath = "test";
-
-		const settings = { appData: { [sourcePath]: { [123456]: appData } } };
-		const newSettings = pruneSettingsCache(settings, sourcePath, fileData);
-		expect(newSettings.appData[sourcePath][1233456]).toBe(undefined);
+		const data = findAppData(table);
+		const markdown = appDataToMarkdown(tableId, data);
+		expect(markdown).toEqual(
+			"| Column 1  | Column 2       |\n| --------- | -------------- |\n| 123456    |                |\n| text      | text           |\n| some text | some more text |"
+		);
 	});
 });
 
-describe("hashMarkdownTable", () => {
-	it("returns the same hash for the same data", () => {
-		const parsedTable = [
-			["Column 1", "Column 2"],
-			["text", "text"],
-			["some text", "some more text"],
-		];
-		const appData = findAppData(parsedTable);
-		const markdownTable = appDataToString(appData);
-		const hash1 = hashMarkdownTable(markdownTable);
-		const hash2 = hashMarkdownTable(markdownTable);
-		expect(hash1).toEqual(hash2);
-	});
-
-	it("returns the same hash as hashParsedTable", () => {
-		const parsedTable = [
-			["Column 1", "Column 2"],
-			["text", "text"],
-			["some text", "some more text, with comma"],
-		];
-		const appData = findAppData(parsedTable);
-		const markdownTable = appDataToString(appData);
-		const hash1 = hashMarkdownTable(markdownTable);
-		const hash2 = hashParsedTable(parsedTable);
-		expect(hash1).toEqual(hash2);
+describe("AppDataStringBuffer", () => {
+	it("toString returns current value", () => {
+		const buffer = new AppDataStringBuffer();
+		buffer.createRow();
+		buffer.writeColumn("Column 1", 10);
+		buffer.writeColumn("Column 2", 8);
+		buffer.createRow();
+		buffer.writeColumn("Text", 4);
+		expect(buffer.toString()).toEqual(
+			"| Column 1   | Column 2 |\n| Text |"
+		);
 	});
 });
 
-describe("hashParsedTable", () => {
-	it("returns the same hash for the same data", () => {
-		const parsedTable = [
-			["Column 1", "Column 2"],
+describe("calcColumnCharLengths", () => {
+	it("calculates largest string length from header row", () => {
+		const tableId = "123456";
+		const table = [
+			["This is some long text", "Column 2"],
+			[tableId, ""],
 			["text", "text"],
 			["some text", "some more text"],
 		];
-		const hash1 = hashParsedTable(parsedTable);
-		const hash2 = hashParsedTable(parsedTable);
-		expect(hash1).toEqual(hash2);
+		const data = findAppData(table);
+		const lengths = calcColumnCharLengths(
+			tableId,
+			data.headers,
+			data.cells,
+			data.tags
+		);
+		expect(lengths).toEqual([22, 14]);
+	});
+
+	it("calculates largest string length from tableId row", () => {
+		const tableId = "this-is-a-long-table-id";
+		const table = [
+			["Column 1", "Column 2"],
+			[tableId, ""],
+			["text", "text"],
+			["some text", "some more text"],
+		];
+		const data = findAppData(table);
+		const lengths = calcColumnCharLengths(
+			tableId,
+			data.headers,
+			data.cells,
+			data.tags
+		);
+		expect(lengths).toEqual([23, 14]);
+	});
+
+	it("calculates largest string length from type definition row", () => {
+		const tableId = "123456";
+		const table = [
+			["Column 1", "Column 2"],
+			[tableId, ""],
+			["this-is-a-long-value", "text"],
+			["some text", "some more text"],
+		];
+		const data = findAppData(table);
+		const lengths = calcColumnCharLengths(
+			tableId,
+			data.headers,
+			data.cells,
+			data.tags
+		);
+		expect(lengths).toEqual([20, 14]);
+	});
+
+	it("calculates largest string length from text row", () => {
+		const tableId = "123456";
+		const table = [
+			["Column 1", "Column 2"],
+			[tableId, ""],
+			["text", "text"],
+			["This is a long value", "some more text"],
+		];
+		const data = findAppData(table);
+		const lengths = calcColumnCharLengths(
+			data.headers,
+			data.cells,
+			data.tags
+		);
+		expect(lengths).toEqual([20, 14]);
+	});
+
+	it("calculates largest string length from tag row", () => {
+		const tableId = "123456";
+		const table = [
+			["Column 1", "Column 2"],
+			[tableId, ""],
+			["tag", "text"],
+			["#this-is-a-long-tag", "some more text"],
+		];
+		const data = findAppData(table);
+		const lengths = calcColumnCharLengths(
+			data.headers,
+			data.cells,
+			data.tags
+		);
+		expect(lengths).toEqual([18, 14]);
 	});
 });
 
-describe("mergeAppData", () => {
-	it("merges new cell content", () => {
-		const oldAppData = findAppData([
+describe("findTableRegex", () => {
+	it("produces a regex that matches the data", () => {
+		const tableId = "123456";
+		const table = [
+			["Column 1", "Column 2"],
+			[tableId, ""],
+			["text", "text"],
+			["some text", "some more text"],
+		];
+		const data = findAppData(table);
+		const regex = findTableRegex(tableId, data.headers, data.rows);
+		expect(regex.toString()).toEqual(
+			"/\\|.*\\|\\n\\|.*\\|\\n\\|[\\t ]+123456[\\t ]+\\|.*\\|\\n\\|.*\\|\\n\\|.*\\|/"
+		);
+
+		const string = appDataToMarkdown(tableId, data);
+		expect((string.match(regex) || []).length).toEqual(1);
+	});
+});
+
+describe("createEmptyTable", () => {
+	it("creates an empty 1 column table", () => {
+		const uuid = randomTableId();
+		const table = createEmptyTable(uuid);
+		expect(table).toMatch(
+			`| Column 1 |\n| -------- |\n| ${uuid} |\n| text |`
+		);
+	});
+});
+
+describe("findTableId", () => {
+	it("returns the table id", () => {
+		const parsedTable = [
+			["column1", "column2"],
+			["12345", ""],
+			["text", "text"],
+			["test1", "test2"],
+		];
+		const id = findTableId(parsedTable);
+		expect(id).toEqual("12345");
+	});
+
+	it("returns null if row doesn't exist", () => {
+		const parsedTable = [
 			["column1", "column2"],
 			["text", "text"],
 			["test1", "test2"],
-		]);
-		const newAppData = findAppData([
-			["column1", "column2"],
-			["text", "text"],
-			["updated1", "updated2"],
-		]);
-
-		const merged = mergeAppData(oldAppData, newAppData);
-		//Check content
-		expect(merged.cells[0].content).toEqual("updated1");
-		expect(merged.cells[1].content).toEqual("updated2");
+		];
+		const id = findTableId(parsedTable);
+		expect(id).toEqual(null);
 	});
 
-	it("merges new tag content", () => {
-		const oldAppData = findAppData([
+	it("returns null if id is blank", () => {
+		const parsedTable = [
 			["column1", "column2"],
-			["tag", "tag"],
-			["#tag1", "#tag2"],
-		]);
-		const newAppData = findAppData([
-			["column1", "column2"],
-			["tag", "tag"],
-			["#updated1", "#updated2"],
-		]);
-
-		const merged = mergeAppData(oldAppData, newAppData);
-		expect(merged.tags[0].content).toEqual("updated1");
-		expect(merged.tags[1].content).toEqual("updated2");
-	});
-
-	it("merges new cell content", () => {
-		const oldAppData = findAppData([
-			["column1", "column2"],
-			["tag", "tag"],
-			["#tag1", "#tag2"],
-		]);
-		const newAppData = findAppData([
-			["column1", "column2"],
-			["tag", "tag"],
-			["#tag2", "#tag3"],
-		]);
-
-		const merged = mergeAppData(oldAppData, newAppData);
-		expect(merged.tags[0].color).toEqual(oldAppData.tags[1].color);
-		expect(merged.tags[1].color).toEqual(newAppData.tags[1].color);
-		expect(merged.tags[0].content).toEqual("tag2");
-		expect(merged.tags[1].content).toEqual("tag3");
-	});
-
-	it("merges row creation times", () => {
-		const oldAppData = findAppData([
-			["column1", "column2"],
+			["", ""],
 			["text", "text"],
-			["row1-cell1", "row1-cell2"],
-			["row2-cell1", "row2-cell2"],
-		]);
-		const newAppData = findAppData([
-			["column1", "column2"],
-			["text", "text"],
-			["updated-row1-cell1", "updated-row1-cell2"],
-			["updated-row2-cell1", "updated-row2-cell2"],
-		]);
-
-		const merged = mergeAppData(oldAppData, newAppData);
-		expect(merged.rows[0].creationTime).toEqual(
-			oldAppData.rows[0].creationTime
-		);
-		expect(merged.rows[1].creationTime).toEqual(
-			newAppData.rows[1].creationTime
-		);
+			["test1", "test2"],
+		];
+		const id = findTableId(parsedTable);
+		expect(id).toEqual(null);
 	});
 });
+
+// describe("mergeAppData", () => {
+// 	it("merges new cell content", () => {
+// 		const oldAppData = findAppData([
+// 			["column1", "column2"],
+// 			["text", "text"],
+// 			["test1", "test2"],
+// 		]);
+// 		const newAppData = findAppData([
+// 			["column1", "column2"],
+// 			["text", "text"],
+// 			["updated1", "updated2"],
+// 		]);
+
+// 		const merged = mergeAppData(oldAppData, newAppData);
+// 		//Check content
+// 		expect(merged.cells[0].content).toEqual("updated1");
+// 		expect(merged.cells[1].content).toEqual("updated2");
+// 	});
+
+// 	it("merges new tag content", () => {
+// 		const oldAppData = findAppData([
+// 			["column1", "column2"],
+// 			["tag", "tag"],
+// 			["#tag1", "#tag2"],
+// 		]);
+// 		const newAppData = findAppData([
+// 			["column1", "column2"],
+// 			["tag", "tag"],
+// 			["#updated1", "#updated2"],
+// 		]);
+
+// 		const merged = mergeAppData(oldAppData, newAppData);
+// 		expect(merged.tags[0].content).toEqual("updated1");
+// 		expect(merged.tags[1].content).toEqual("updated2");
+// 	});
+
+// 	it("merges new cell content", () => {
+// 		const oldAppData = findAppData([
+// 			["column1", "column2"],
+// 			["tag", "tag"],
+// 			["#tag1", "#tag2"],
+// 		]);
+// 		const newAppData = findAppData([
+// 			["column1", "column2"],
+// 			["tag", "tag"],
+// 			["#tag2", "#tag3"],
+// 		]);
+
+// 		const merged = mergeAppData(oldAppData, newAppData);
+// 		expect(merged.tags[0].color).toEqual(oldAppData.tags[1].color);
+// 		expect(merged.tags[1].color).toEqual(newAppData.tags[1].color);
+// 		expect(merged.tags[0].content).toEqual("tag2");
+// 		expect(merged.tags[1].content).toEqual("tag3");
+// 	});
+
+// 	it("merges row creation times", () => {
+// 		const oldAppData = findAppData([
+// 			["column1", "column2"],
+// 			["text", "text"],
+// 			["row1-cell1", "row1-cell2"],
+// 			["row2-cell1", "row2-cell2"],
+// 		]);
+// 		const newAppData = findAppData([
+// 			["column1", "column2"],
+// 			["text", "text"],
+// 			["updated-row1-cell1", "updated-row1-cell2"],
+// 			["updated-row2-cell1", "updated-row2-cell2"],
+// 		]);
+
+// 		const merged = mergeAppData(oldAppData, newAppData);
+// 		expect(merged.rows[0].creationTime).toEqual(
+// 			oldAppData.rows[0].creationTime
+// 		);
+// 		expect(merged.rows[1].creationTime).toEqual(
+// 			newAppData.rows[1].creationTime
+// 		);
+// 	});
+// });
 
 describe("findAppData", () => {
 	it("finds text data", () => {
 		const table = [
 			["Column 1", "Column 2"],
+			["12345", ""],
 			["text", "text"],
 			["some text", "some more text"],
 		];
@@ -203,6 +316,7 @@ describe("findAppData", () => {
 	it("finds tag data", () => {
 		const table = [
 			["Column 1", "Column 2"],
+			["12345", ""],
 			["tag", "tag"],
 			["#tag1", "#tag2"],
 		];
@@ -216,26 +330,28 @@ describe("findAppData", () => {
 
 describe("validTypeDefinitionRow", () => {
 	it("returns true if row exists", () => {
-		const table = [
+		const parsedTable = [
 			["Column 1", "Column 2"],
+			["12345", ""],
 			["text", "text"],
 		];
-		const hasTDR = validTypeDefinitionRow(table);
+		const hasTDR = validTypeDefinitionRow(parsedTable);
 		expect(hasTDR).toBe(true);
 	});
 
 	it("returns false if no row exists", () => {
-		const table = [["Column 1", "Column 2"]];
-		const hasTDR = validTypeDefinitionRow(table);
+		const parsedTable = [["Column 1", "Column 2"]];
+		const hasTDR = validTypeDefinitionRow(parsedTable);
 		expect(hasTDR).toBe(false);
 	});
 
 	it("returns false if invalid types", () => {
-		const table = [
+		const parsedTable = [
 			["Column 1", "Column 2"],
+			["12345", ""],
 			["text", "invalid"],
 		];
-		const hasTDR = validTypeDefinitionRow(table);
+		const hasTDR = validTypeDefinitionRow(parsedTable);
 		expect(hasTDR).toBe(false);
 	});
 });

--- a/src/app/services/utils/index.test.js
+++ b/src/app/services/utils/index.test.js
@@ -219,84 +219,115 @@ describe("findTableId", () => {
 	});
 });
 
-// describe("mergeAppData", () => {
-// 	it("merges new cell content", () => {
-// 		const oldAppData = findAppData([
-// 			["column1", "column2"],
-// 			["text", "text"],
-// 			["test1", "test2"],
-// 		]);
-// 		const newAppData = findAppData([
-// 			["column1", "column2"],
-// 			["text", "text"],
-// 			["updated1", "updated2"],
-// 		]);
+describe("mergeAppData", () => {
+	it("merges new header content", () => {
+		const oldAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["text", "text"],
+			["test 1", "test 2"],
+		]);
+		const newAppData = findAppData([
+			["Column 3", "Column 4"],
+			["123456", ""],
+			["text", "text"],
+			["test 1", "test 2"],
+		]);
 
-// 		const merged = mergeAppData(oldAppData, newAppData);
-// 		//Check content
-// 		expect(merged.cells[0].content).toEqual("updated1");
-// 		expect(merged.cells[1].content).toEqual("updated2");
-// 	});
+		const merged = mergeAppData(oldAppData, newAppData);
+		//Check content
+		expect(merged.headers[0].content).toEqual("Column 3");
+		expect(merged.headers[1].content).toEqual("Column 4");
+	});
 
-// 	it("merges new tag content", () => {
-// 		const oldAppData = findAppData([
-// 			["column1", "column2"],
-// 			["tag", "tag"],
-// 			["#tag1", "#tag2"],
-// 		]);
-// 		const newAppData = findAppData([
-// 			["column1", "column2"],
-// 			["tag", "tag"],
-// 			["#updated1", "#updated2"],
-// 		]);
+	it("merges new cell content", () => {
+		const oldAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["text", "text"],
+			["test 1", "test 2"],
+		]);
+		const newAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["text", "text"],
+			["updated 1", "updated 2"],
+		]);
 
-// 		const merged = mergeAppData(oldAppData, newAppData);
-// 		expect(merged.tags[0].content).toEqual("updated1");
-// 		expect(merged.tags[1].content).toEqual("updated2");
-// 	});
+		const merged = mergeAppData(oldAppData, newAppData);
+		//Check content
+		expect(merged.cells[0].content).toEqual("updated 1");
+		expect(merged.cells[1].content).toEqual("updated 2");
+	});
 
-// 	it("merges new cell content", () => {
-// 		const oldAppData = findAppData([
-// 			["column1", "column2"],
-// 			["tag", "tag"],
-// 			["#tag1", "#tag2"],
-// 		]);
-// 		const newAppData = findAppData([
-// 			["column1", "column2"],
-// 			["tag", "tag"],
-// 			["#tag2", "#tag3"],
-// 		]);
+	it("merges updated column type", () => {
+		const oldAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["text", "text"],
+			["test 1", "test 2"],
+		]);
+		const newAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["number", "tag"],
+			["25", "#test"],
+		]);
 
-// 		const merged = mergeAppData(oldAppData, newAppData);
-// 		expect(merged.tags[0].color).toEqual(oldAppData.tags[1].color);
-// 		expect(merged.tags[1].color).toEqual(newAppData.tags[1].color);
-// 		expect(merged.tags[0].content).toEqual("tag2");
-// 		expect(merged.tags[1].content).toEqual("tag3");
-// 	});
+		const merged = mergeAppData(oldAppData, newAppData);
+		expect(merged.headers[0].type).toEqual(CELL_TYPE.NUMBER);
+		expect(merged.headers[1].type).toEqual(CELL_TYPE.TAG);
+		expect(merged.cells[0].content).toEqual("25");
+		expect(merged.tags[0].content).toEqual("test");
+		expect(merged.tags[0].color).toEqual(newAppData.tags[0].color);
+	});
 
-// 	it("merges row creation times", () => {
-// 		const oldAppData = findAppData([
-// 			["column1", "column2"],
-// 			["text", "text"],
-// 			["row1-cell1", "row1-cell2"],
-// 			["row2-cell1", "row2-cell2"],
-// 		]);
-// 		const newAppData = findAppData([
-// 			["column1", "column2"],
-// 			["text", "text"],
-// 			["updated-row1-cell1", "updated-row1-cell2"],
-// 			["updated-row2-cell1", "updated-row2-cell2"],
-// 		]);
+	it("merges new tag content", () => {
+		const oldAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["tag", "tag"],
+			["#tag1", "#tag2"],
+		]);
+		const newAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["tag", "tag"],
+			["#tag2", "#tag3"],
+		]);
 
-// 		const merged = mergeAppData(oldAppData, newAppData);
-// 		expect(merged.rows[0].creationTime).toEqual(
-// 			oldAppData.rows[0].creationTime
-// 		);
-// 		expect(merged.rows[1].creationTime).toEqual(
-// 			newAppData.rows[1].creationTime
-// 		);
-// 	});
-// });
+		const merged = mergeAppData(oldAppData, newAppData);
+		expect(merged.tags[0].color).toEqual(oldAppData.tags[1].color);
+		expect(merged.tags[1].color).toEqual(newAppData.tags[1].color);
+		expect(merged.tags[0].content).toEqual("tag2");
+		expect(merged.tags[1].content).toEqual("tag3");
+	});
+
+	it("merges row creation times", () => {
+		const oldAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["text", "text"],
+			["test 1", "test 2"],
+			["test 3", "test 4"],
+		]);
+		const newAppData = findAppData([
+			["Column 1", "Column 2"],
+			["123456", ""],
+			["text", "text"],
+			["updated 1", "test 2"],
+			["test 3", "updated 4"],
+		]);
+
+		const merged = mergeAppData(oldAppData, newAppData);
+		expect(merged.rows[0].creationTime).toEqual(
+			oldAppData.rows[0].creationTime
+		);
+		expect(merged.rows[1].creationTime).toEqual(
+			newAppData.rows[1].creationTime
+		);
+	});
+});
 
 describe("findAppData", () => {
 	it("finds text data", () => {

--- a/src/app/services/utils/index.ts
+++ b/src/app/services/utils/index.ts
@@ -1,4 +1,3 @@
-import { buffer } from "stream/consumers";
 import { v4 as uuidv4 } from "uuid";
 
 import { CELL_COLOR, CELL_TYPE } from "../../constants";

--- a/src/app/services/utils/index.ts
+++ b/src/app/services/utils/index.ts
@@ -225,9 +225,17 @@ export const mergeAppData = (
 		merged.headers[i].sortName = headers.sortName;
 	});
 
+	//Algorithm:
+	//Sort by default first and then find
+	//This allows the user to add new rows or delete existing rows
+	//and still have the correct creationTime
 	//Grab row settings
-	oldAppData.rows.forEach((row, i) => {
-		merged.rows[i].creationTime = row.creationTime;
+	newAppData.rows.forEach((row, i) => {
+		if (oldAppData.rows.length >= i + 1) {
+			merged.rows[i].creationTime = oldAppData.rows[i].creationTime;
+		} else {
+			merged.rows[i].creationTime = row.creationTime;
+		}
 	});
 
 	//Grab tag settings
@@ -266,7 +274,7 @@ export const findAppData = (parsedTable: string[][]): AppData => {
 			//Since these operations are preformed very quickly, it's possible
 			//for our to get the same time
 			//Add a timeoffset to make sure the time is different
-			const time = Date.now() + i;
+			const time = Math.round(Date.now() - Math.random() * 1000);
 			rows.push(initialRow(rowId, time));
 
 			row.forEach((td, j) => {

--- a/src/app/services/utils/index.ts
+++ b/src/app/services/utils/index.ts
@@ -32,8 +32,10 @@ export const pruneSettingsCache = (
 
 		Object.keys(obj.appData[sourcePath]).forEach((key) => {
 			const hash = parseInt(key);
-			if (!tableHashes.includes(hash))
+			if (!tableHashes.includes(hash)) {
+				//console.log("PRUNING DATA", hash);
 				delete obj.appData[sourcePath][hash];
+			}
 		});
 	}
 	return obj;
@@ -48,7 +50,12 @@ export const hashMarkdownTable = (markdownTable: string): number => {
 };
 
 export const hashParsedTable = (parsedTable: string[][]): number => {
-	const output = parsedTable.join("").replace(/,/g, "").replace(/\s/g, "");
+	let output = "";
+	for (let i = 0; i < parsedTable.length; i++) {
+		for (let j = 0; j < parsedTable[i].length; j++) {
+			output += parsedTable[i][j].replace(/\s/g, "");
+		}
+	}
 	return crc32.str(output);
 };
 


### PR DESCRIPTION
- Fixed #60 
- Added support for adding new rows to markdown

- Added suggestions from Lishid:
  -  Replaced `read` with `cachedRead` for improved performance
  -  Added missing `await`
  -  Replaced `leaf.duplicate()` and `leaf.detach()` with `MarkdownPreviewView.rerender`
  - Remove on`("editor-change")`

- Stopped new data persist call on live preview table click
- Refactored to new caching system using table id
  - Tables are now independent of headers/data. The markdown can be safely changed
  - Multiple tables can have the exact same information but still act independently
  - Updated README
- Fixed bug where if you pressed enter to create a tag, it would get a new color
- Added tests for data saving