### PR TITLE
Bug/flashing menus

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState } from "react";
 
 import EditableTd from "./components/EditableTd";
 import Table from "./components/Table";
@@ -21,8 +21,6 @@ import { SORT } from "./components/HeaderMenu/constants";
 import { addRow, addColumn } from "./services/appData/internal/add";
 import { randomCellId, randomColumnId, randomRowId } from "./services/random";
 import { findCurrentViewType } from "./services/appData/external/loadUtils";
-import { start } from "repl";
-
 interface Props {
 	plugin: NltPlugin;
 	settings: NltSettings;

--- a/src/app/components/CheckboxCell/index.tsx
+++ b/src/app/components/CheckboxCell/index.tsx
@@ -17,10 +17,7 @@ export default function CheckboxCell({ isChecked, onCheckboxChange }: Props) {
 				className="task-list-item-checkbox"
 				type="checkbox"
 				checked={isChecked}
-				onChange={(e) => {
-					e.stopPropagation();
-					onCheckboxChange(!isChecked);
-				}}
+				onChange={() => onCheckboxChange(!isChecked)}
 			/>
 		</div>
 	);

--- a/src/app/components/DateCellEdit/index.tsx
+++ b/src/app/components/DateCellEdit/index.tsx
@@ -11,8 +11,8 @@ interface Props {
 	isOpen: boolean;
 	top: number;
 	left: number;
-	width: string;
-	height: string;
+	width: number;
+	height: number;
 	selectedDate: Date;
 	onDateChange: (date: Date) => void;
 }

--- a/src/app/components/EditableTd/index.tsx
+++ b/src/app/components/EditableTd/index.tsx
@@ -52,21 +52,19 @@ export default function EditableTd({
 }: Props) {
 	const [inputText, setInputText] = useState("");
 	const [cellMenu, setCellMenu] = useState({
-		// top: -4,
-		// left: -11,
 		top: 0,
 		left: 0,
 		width: "0px",
 		height: "0px",
 		tagColor: randomColor(),
 	});
-	const { isMenuOpen, openMenu } = useMenu();
 
 	const [menuId] = useState(uuidv4());
 
 	const content = cell.toString();
 	const { id, headerId, type, expectedType } = cell;
 	const didMount = useRef(false);
+	const { isOpen, open } = useMenu(menuId, MENU_LEVEL.ONE);
 
 	const tdRef = useCallback(
 		(node) => {
@@ -90,7 +88,7 @@ export default function EditableTd({
 				}
 			}
 		},
-		[inputText.length, isMenuOpen(menuId)]
+		[inputText.length, isOpen]
 	);
 
 	async function handleCellContextClick(e: React.MouseEvent<HTMLElement>) {
@@ -113,7 +111,7 @@ export default function EditableTd({
 		if (el.nodeName === "A") return;
 		if (type === CELL_TYPE.ERROR) return;
 
-		openMenu(menuId, MENU_LEVEL.ONE);
+		open();
 	}
 
 	function handleAddTag(text: string) {
@@ -224,7 +222,7 @@ export default function EditableTd({
 				return (
 					<TextCellEdit
 						menuId={menuId}
-						isOpen={isMenuOpen(menuId)}
+						isOpen={isOpen}
 						top={cellMenu.top}
 						left={cellMenu.left}
 						width={cellMenu.width}
@@ -236,7 +234,7 @@ export default function EditableTd({
 				return (
 					<NumberCellEdit
 						menuId={menuId}
-						isOpen={isMenuOpen(menuId)}
+						isOpen={isOpen}
 						top={cellMenu.top}
 						left={cellMenu.left}
 						width={cellMenu.width}
@@ -250,7 +248,7 @@ export default function EditableTd({
 						cellId={id}
 						tags={tags}
 						menuId={menuId}
-						isOpen={isMenuOpen(menuId)}
+						isOpen={isOpen}
 						top={cellMenu.top}
 						left={cellMenu.left}
 						inputText={inputText}
@@ -266,7 +264,7 @@ export default function EditableTd({
 				return (
 					<DateCellEdit
 						menuId={menuId}
-						isOpen={isMenuOpen(menuId)}
+						isOpen={isOpen}
 						top={cellMenu.top}
 						left={cellMenu.left}
 						width={cellMenu.width}
@@ -286,7 +284,7 @@ export default function EditableTd({
 		if (!didMount.current) {
 			didMount.current = true;
 		} else {
-			if (!isMenuOpen(menuId)) {
+			if (!isOpen) {
 				if (DEBUG.EDITABLE_TD.USE_EFFECT)
 					console.log(
 						`[EditableTd] useEffect(updateContent("${inputText}"))`
@@ -294,7 +292,7 @@ export default function EditableTd({
 				updateContent(inputText);
 			}
 		}
-	}, [didMount.current, isMenuOpen(menuId)]);
+	}, [didMount.current, isOpen]);
 
 	useEffect(() => {
 		if (DEBUG.EDITABLE_TD.USE_EFFECT)
@@ -314,7 +312,7 @@ export default function EditableTd({
 			onContextMenu={handleCellContextClick}
 		>
 			{renderCellMenu()}
-			<div className="NLT__td-content-container" style={{ width }}>
+			<div className="NLT__td-container" style={{ width }}>
 				{renderCell()}
 			</div>
 		</td>

--- a/src/app/components/EditableTd/index.tsx
+++ b/src/app/components/EditableTd/index.tsx
@@ -114,19 +114,19 @@ export default function EditableTd({
 		openMenu();
 	}
 
-	function handleAddTag(text: string) {
+	//Are menus saving??
+	async function handleAddTag(text: string) {
 		if (DEBUG.EDITABLE_TD.HANDLER)
 			console.log(`[EditableTd] handleAddTag("${text}")`);
-		onAddTag(id, headerId, text, tagColor);
-		setInputText("");
 		closeMenu();
+		onAddTag(id, headerId, text, tagColor);
 	}
 
-	function handleTagClick(tagId: string) {
+	async function handleTagClick(tagId: string) {
 		if (DEBUG.EDITABLE_TD.HANDLER)
 			console.log(`[EditableTd] handleTagClick("${tagId}")`);
-		onTagClick(id, tagId);
 		closeMenu();
+		onTagClick(id, tagId);
 	}
 
 	function updateContent(updated: string) {

--- a/src/app/components/EditableTd/index.tsx
+++ b/src/app/components/EditableTd/index.tsx
@@ -91,6 +91,30 @@ export default function EditableTd({
 		[inputText.length, isOpen]
 	);
 
+	useEffect(() => {
+		if (!didMount.current) {
+			didMount.current = true;
+		} else {
+			if (!isOpen) {
+				if (DEBUG.EDITABLE_TD.USE_EFFECT)
+					console.log(
+						`[EditableTd] useEffect(updateContent("${inputText}"))`
+					);
+				updateContent(inputText);
+			}
+		}
+	}, [didMount.current, isOpen]);
+
+	useEffect(() => {
+		if (DEBUG.EDITABLE_TD.USE_EFFECT)
+			console.log(`[EditableTd] useEffect(setInputText("${content}"))`);
+		setInputText(content);
+	}, []);
+
+	useEffect(() => {
+		didMount.current = true;
+	}, []);
+
 	async function handleCellContextClick(e: React.MouseEvent<HTMLElement>) {
 		if (DEBUG.EDITABLE_TD.HANDLER)
 			console.log("[EditableTd] handleCellContextClick()");
@@ -113,6 +137,8 @@ export default function EditableTd({
 
 		open();
 	}
+
+	function openMenu() {}
 
 	function handleAddTag(text: string) {
 		if (DEBUG.EDITABLE_TD.HANDLER)
@@ -279,30 +305,6 @@ export default function EditableTd({
 				return <></>;
 		}
 	}
-
-	useEffect(() => {
-		if (!didMount.current) {
-			didMount.current = true;
-		} else {
-			if (!isOpen) {
-				if (DEBUG.EDITABLE_TD.USE_EFFECT)
-					console.log(
-						`[EditableTd] useEffect(updateContent("${inputText}"))`
-					);
-				updateContent(inputText);
-			}
-		}
-	}, [didMount.current, isOpen]);
-
-	useEffect(() => {
-		if (DEBUG.EDITABLE_TD.USE_EFFECT)
-			console.log(`[EditableTd] useEffect(setInputText("${content}"))`);
-		setInputText(content);
-	}, []);
-
-	useEffect(() => {
-		didMount.current = true;
-	}, []);
 
 	return (
 		<td

--- a/src/app/components/EditableTd/index.tsx
+++ b/src/app/components/EditableTd/index.tsx
@@ -58,10 +58,8 @@ export default function EditableTd({
 	const [tagColor] = useState(randomColor());
 
 	const menuId = useMenuId();
-	const { menuPosition, menuRef, isMenuOpen, openMenu } = useMenuRef(
-		menuId,
-		MENU_LEVEL.ONE
-	);
+	const { menuPosition, menuRef, isMenuOpen, openMenu, canOpenMenu } =
+		useMenuRef(menuId, MENU_LEVEL.ONE);
 
 	useDisableScroll(isMenuOpen);
 
@@ -110,9 +108,12 @@ export default function EditableTd({
 
 		//If we clicked on the link for a file or tag, return
 		if (el.nodeName === "A") return;
+		//If the cell is an error return
 		if (type === CELL_TYPE.ERROR) return;
 
-		openMenu();
+		if (canOpenMenu()) {
+			openMenu();
+		}
 	}
 
 	function handleAddTag(text: string) {

--- a/src/app/components/EditableTd/index.tsx
+++ b/src/app/components/EditableTd/index.tsx
@@ -58,8 +58,14 @@ export default function EditableTd({
 	const [tagColor] = useState(randomColor());
 
 	const menuId = useMenuId();
-	const { menuPosition, menuRef, isMenuOpen, openMenu, canOpenMenu } =
-		useMenuRef(menuId, MENU_LEVEL.ONE);
+	const {
+		menuPosition,
+		menuRef,
+		isMenuOpen,
+		openMenu,
+		canOpenMenu,
+		closeMenu,
+	} = useMenuRef(menuId, MENU_LEVEL.ONE);
 
 	useDisableScroll(isMenuOpen);
 
@@ -121,12 +127,14 @@ export default function EditableTd({
 			console.log(`[EditableTd] handleAddTag("${text}")`);
 		onAddTag(id, headerId, text, tagColor);
 		setInputText("");
+		closeMenu();
 	}
 
 	function handleTagClick(tagId: string) {
 		if (DEBUG.EDITABLE_TD.HANDLER)
 			console.log(`[EditableTd] handleTagClick("${tagId}")`);
 		onTagClick(id, tagId);
+		closeMenu();
 	}
 
 	function updateContent(updated: string) {

--- a/src/app/components/EditableTd/index.tsx
+++ b/src/app/components/EditableTd/index.tsx
@@ -23,7 +23,7 @@ import { parseDateForInput } from "src/app/services/string/parsers";
 import "./styles.css";
 
 import { CELL_TYPE, DEBUG, MENU_LEVEL } from "../../constants";
-import { useResizeTime } from "src/app/services/hooks";
+import { useDisableScroll, useResizeTime } from "src/app/services/hooks";
 
 interface Props {
 	cell: Cell;
@@ -67,6 +67,7 @@ export default function EditableTd({
 	const didMount = useRef(false);
 	const { isOpen, open } = useMenu(menuId, MENU_LEVEL.ONE);
 	const resizeTime = useResizeTime();
+	useDisableScroll(isOpen);
 
 	const tdRef = useCallback(
 		(node) => {

--- a/src/app/components/EditableTd/index.tsx
+++ b/src/app/components/EditableTd/index.tsx
@@ -23,6 +23,7 @@ import { parseDateForInput } from "src/app/services/string/parsers";
 import "./styles.css";
 
 import { CELL_TYPE, DEBUG, MENU_LEVEL } from "../../constants";
+import { useResizeTime } from "src/app/services/hooks";
 
 interface Props {
 	cell: Cell;
@@ -65,6 +66,7 @@ export default function EditableTd({
 	const { id, headerId, type, expectedType } = cell;
 	const didMount = useRef(false);
 	const { isOpen, open } = useMenu(menuId, MENU_LEVEL.ONE);
+	const resizeTime = useResizeTime();
 
 	const tdRef = useCallback(
 		(node) => {
@@ -72,23 +74,21 @@ export default function EditableTd({
 				if (node instanceof HTMLElement) {
 					//Set timeout to overcome bug where all values in the node are 0
 					//See: https://github.com/facebook/react/issues/13108
-					setTimeout(() => {
-						setCellMenu((prevState) => {
-							const { top, left, width, height } =
-								node.getBoundingClientRect();
-							return {
-								...prevState,
-								top,
-								left,
-								width: `${width}px`,
-								height: `${height}px`,
-							};
-						});
-					}, 1);
+					setCellMenu((prevState) => {
+						const { top, left, width, height } =
+							node.getBoundingClientRect();
+						return {
+							...prevState,
+							top,
+							left,
+							width: `${width}px`,
+							height: `${height}px`,
+						};
+					});
 				}
 			}
 		},
-		[inputText.length, isOpen]
+		[inputText.length, isOpen, resizeTime]
 	);
 
 	useEffect(() => {
@@ -137,8 +137,6 @@ export default function EditableTd({
 
 		open();
 	}
-
-	function openMenu() {}
 
 	function handleAddTag(text: string) {
 		if (DEBUG.EDITABLE_TD.HANDLER)

--- a/src/app/components/EditableTd/index.tsx
+++ b/src/app/components/EditableTd/index.tsx
@@ -58,14 +58,8 @@ export default function EditableTd({
 	const [tagColor] = useState(randomColor());
 
 	const menuId = useMenuId();
-	const {
-		menuPosition,
-		menuRef,
-		isMenuOpen,
-		openMenu,
-		canOpenMenu,
-		closeMenu,
-	} = useMenuRef(menuId, MENU_LEVEL.ONE);
+	const { menuPosition, menuRef, isMenuOpen, openMenu, closeMenu } =
+		useMenuRef(menuId, MENU_LEVEL.ONE);
 
 	useDisableScroll(isMenuOpen);
 
@@ -117,9 +111,7 @@ export default function EditableTd({
 		//If the cell is an error return
 		if (type === CELL_TYPE.ERROR) return;
 
-		if (canOpenMenu()) {
-			openMenu();
-		}
+		openMenu();
 	}
 
 	function handleAddTag(text: string) {

--- a/src/app/components/EditableTh/index.tsx
+++ b/src/app/components/EditableTh/index.tsx
@@ -51,12 +51,12 @@ export default function EditableTh({
 	const [menuId] = useState(uuidv4());
 	const [resizeTime, setResizeTime] = useState(0);
 	const dragRef = useRef(false);
-	const { isMenuOpen, openMenu, closeMenu } = useMenu();
+	const { isOpen, open, close } = useMenu(menuId, MENU_LEVEL.ONE);
 
 	function handleHeaderClick(e: React.MouseEvent) {
-		if (isMenuOpen(menuId)) return;
+		if (isOpen) return;
 		if (dragRef.current) return;
-		openMenu(menuId, MENU_LEVEL.ONE);
+		open();
 	}
 
 	function handleMouseMove(e: MouseEvent) {
@@ -71,7 +71,7 @@ export default function EditableTh({
 	}
 
 	function handleClose() {
-		closeMenu(menuId);
+		close();
 	}
 
 	function handleDrag(e: DragEvent) {
@@ -105,7 +105,7 @@ export default function EditableTh({
 				}
 			}
 		},
-		[isMenuOpen(menuId)]
+		[isOpen]
 	);
 
 	return (
@@ -115,7 +115,7 @@ export default function EditableTh({
 			onClick={handleHeaderClick}
 		>
 			<HeaderMenu
-				isOpen={isMenuOpen(menuId)}
+				isOpen={isOpen}
 				top={headerPosition.top}
 				left={headerPosition.left}
 				id={id}

--- a/src/app/components/EditableTh/index.tsx
+++ b/src/app/components/EditableTh/index.tsx
@@ -52,21 +52,13 @@ export default function EditableTh({
 }: Props) {
 	const dragRef = useRef(false);
 	const menuId = useMenuId();
-	const {
-		menuPosition,
-		menuRef,
-		isMenuOpen,
-		openMenu,
-		closeMenu,
-		canOpenMenu,
-	} = useMenuRef(menuId, MENU_LEVEL.ONE);
+	const { menuPosition, menuRef, isMenuOpen, openMenu, closeMenu } =
+		useMenuRef(menuId, MENU_LEVEL.ONE);
 	useDisableScroll(isMenuOpen);
 
 	function handleHeaderClick(e: React.MouseEvent) {
 		if (dragRef.current) return;
-		if (canOpenMenu()) {
-			openMenu();
-		}
+		openMenu();
 	}
 
 	function handleMouseMove(e: MouseEvent) {

--- a/src/app/components/EditableTh/index.tsx
+++ b/src/app/components/EditableTh/index.tsx
@@ -143,6 +143,7 @@ export default function EditableTh({
 							window.addEventListener("drag", handleDrag);
 						}}
 						onClick={(e) => {
+							//Stop propagation so we don't open the header
 							e.stopPropagation();
 						}}
 					/>

--- a/src/app/components/EditableTh/index.tsx
+++ b/src/app/components/EditableTh/index.tsx
@@ -8,7 +8,12 @@ import HeaderMenu from "../HeaderMenu";
 
 import "./styles.css";
 import { MENU_LEVEL } from "src/app/constants";
-import { useDisableScroll, useResizeTime } from "src/app/services/hooks";
+import {
+	useDisableScroll,
+	useMenuId,
+	useMenuRef,
+	useResizeTime,
+} from "src/app/services/hooks";
 
 interface Props {
 	id: string;
@@ -45,41 +50,21 @@ export default function EditableTh({
 	onDeleteClick,
 	onSaveClick,
 }: Props) {
-	const [headerPosition, setHeaderPosition] = useState({
-		top: 0,
-		left: 0,
-	});
-	const [menuId] = useState(uuidv4());
 	const dragRef = useRef(false);
-	const resizeTime = useResizeTime();
-	const { isOpen, open, close } = useMenu(menuId, MENU_LEVEL.ONE);
-	useDisableScroll(isOpen);
-
-	const thRef = useCallback(
-		(node) => {
-			if (node) {
-				if (node instanceof HTMLElement) {
-					const { top, left } = node.getBoundingClientRect();
-					setHeaderPosition({
-						top,
-						left,
-					});
-				}
-			}
-		},
-		[resizeTime, isOpen]
-	);
+	const menuId = useMenuId();
+	const { menuPosition, menuRef, isMenuOpen, openMenu, closeMenu } =
+		useMenuRef(menuId, MENU_LEVEL.ONE);
+	useDisableScroll(isMenuOpen);
 
 	function handleHeaderClick(e: React.MouseEvent) {
-		if (isOpen) return;
 		if (dragRef.current) return;
-		open();
+		openMenu();
 	}
 
 	function handleMouseMove(e: MouseEvent) {
 		const target = e.target;
 		if (target instanceof HTMLElement) {
-			let width = e.pageX - headerPosition.left - 17;
+			let width = e.pageX - menuPosition.left - 17;
 			width = parseInt(width.toString());
 			if (width < 30) return;
 			dragRef.current = true;
@@ -88,7 +73,7 @@ export default function EditableTh({
 	}
 
 	function handleClose() {
-		close();
+		closeMenu();
 	}
 
 	function handleDrag(e: DragEvent) {
@@ -111,13 +96,13 @@ export default function EditableTh({
 	return (
 		<th
 			className="NLT__th NLT__selectable"
-			ref={thRef}
+			ref={menuRef}
 			onClick={handleHeaderClick}
 		>
 			<HeaderMenu
-				isOpen={isOpen}
-				top={headerPosition.top}
-				left={headerPosition.left}
+				isOpen={isMenuOpen}
+				top={menuPosition.top}
+				left={menuPosition.left}
 				id={id}
 				menuId={menuId}
 				content={content}

--- a/src/app/components/EditableTh/index.tsx
+++ b/src/app/components/EditableTh/index.tsx
@@ -8,7 +8,7 @@ import HeaderMenu from "../HeaderMenu";
 
 import "./styles.css";
 import { MENU_LEVEL } from "src/app/constants";
-import { useResizeTime } from "src/app/services/hooks";
+import { useDisableScroll, useResizeTime } from "src/app/services/hooks";
 
 interface Props {
 	id: string;
@@ -53,6 +53,7 @@ export default function EditableTh({
 	const dragRef = useRef(false);
 	const resizeTime = useResizeTime();
 	const { isOpen, open, close } = useMenu(menuId, MENU_LEVEL.ONE);
+	useDisableScroll(isOpen);
 
 	const thRef = useCallback(
 		(node) => {

--- a/src/app/components/EditableTh/index.tsx
+++ b/src/app/components/EditableTh/index.tsx
@@ -52,13 +52,21 @@ export default function EditableTh({
 }: Props) {
 	const dragRef = useRef(false);
 	const menuId = useMenuId();
-	const { menuPosition, menuRef, isMenuOpen, openMenu, closeMenu } =
-		useMenuRef(menuId, MENU_LEVEL.ONE);
+	const {
+		menuPosition,
+		menuRef,
+		isMenuOpen,
+		openMenu,
+		closeMenu,
+		canOpenMenu,
+	} = useMenuRef(menuId, MENU_LEVEL.ONE);
 	useDisableScroll(isMenuOpen);
 
 	function handleHeaderClick(e: React.MouseEvent) {
 		if (dragRef.current) return;
-		openMenu();
+		if (canOpenMenu()) {
+			openMenu();
+		}
 	}
 
 	function handleMouseMove(e: MouseEvent) {

--- a/src/app/components/EditableTh/index.tsx
+++ b/src/app/components/EditableTh/index.tsx
@@ -8,6 +8,7 @@ import HeaderMenu from "../HeaderMenu";
 
 import "./styles.css";
 import { MENU_LEVEL } from "src/app/constants";
+import { useResizeTime } from "src/app/services/hooks";
 
 interface Props {
 	id: string;
@@ -49,9 +50,24 @@ export default function EditableTh({
 		left: 0,
 	});
 	const [menuId] = useState(uuidv4());
-	const [resizeTime, setResizeTime] = useState(0);
 	const dragRef = useRef(false);
+	const resizeTime = useResizeTime();
 	const { isOpen, open, close } = useMenu(menuId, MENU_LEVEL.ONE);
+
+	const thRef = useCallback(
+		(node) => {
+			if (node) {
+				if (node instanceof HTMLElement) {
+					const { top, left } = node.getBoundingClientRect();
+					setHeaderPosition({
+						top,
+						left,
+					});
+				}
+			}
+		},
+		[resizeTime, isOpen]
+	);
 
 	function handleHeaderClick(e: React.MouseEvent) {
 		if (isOpen) return;
@@ -90,23 +106,6 @@ export default function EditableTh({
 			dragRef.current = false;
 		}, 50);
 	}
-
-	const thRef = useCallback(
-		(node) => {
-			if (node) {
-				if (node instanceof HTMLElement) {
-					setTimeout(() => {
-						const { top, left } = node.getBoundingClientRect();
-						setHeaderPosition({
-							top,
-							left,
-						});
-					}, 1);
-				}
-			}
-		},
-		[isOpen]
-	);
 
 	return (
 		<th

--- a/src/app/components/Menu/index.tsx
+++ b/src/app/components/Menu/index.tsx
@@ -46,7 +46,6 @@ export default function Menu({
 						</div>
 					</div>,
 					document.body
-					//document.getElementsByClassName("view-content")[0]
 				)}
 		</>
 	);

--- a/src/app/components/Menu/index.tsx
+++ b/src/app/components/Menu/index.tsx
@@ -31,6 +31,7 @@ export default function Menu({
 					<div
 						className="NLT__menu"
 						id={id}
+						onClick={(e) => e.stopPropagation()} //Catch events from menu so we don't open
 						onMouseDown={(e) => e.preventDefault()}
 					>
 						<div

--- a/src/app/components/Menu/index.tsx
+++ b/src/app/components/Menu/index.tsx
@@ -8,8 +8,8 @@ interface Props {
 	isOpen: boolean;
 	top: number;
 	left: number;
-	width?: string;
-	height?: string;
+	width?: number;
+	height?: number;
 	children: React.ReactNode;
 }
 
@@ -38,8 +38,8 @@ export default function Menu({
 							style={{
 								top: `${top}px`,
 								left: `${left}px`,
-								width: width ? width : "fit-content",
-								height: height ? height : "fit-content",
+								width: width ? `${width}px` : "fit-content",
+								height: height ? `${height}px` : "fit-content",
 							}}
 						>
 							{children}

--- a/src/app/components/MenuProvider/index.tsx
+++ b/src/app/components/MenuProvider/index.tsx
@@ -36,11 +36,13 @@ export default function MenuProvider({ children }: Props) {
 	const isFocused = useTableFocus();
 
 	function openMenu(id: string, level: number) {
-		const menu = { id, level };
-		if (DEBUG.MENU_PROVIDER.HANDLER) {
-			console.log(`[MenuProvider]: openMenu("${id}", ${level})`);
+		if (!isMenuOpen(id)) {
+			const menu = { id, level };
+			if (DEBUG.MENU_PROVIDER.HANDLER) {
+				console.log(`[MenuProvider]: openMenu("${id}", ${level})`);
+			}
+			setOpenMenus((prevState) => [...prevState, menu]);
 		}
-		setOpenMenus((prevState) => [...prevState, menu]);
 	}
 
 	function isMenuOpen(id: string): boolean {
@@ -55,10 +57,14 @@ export default function MenuProvider({ children }: Props) {
 	}
 
 	const closeMenu = (id: string) => {
-		if (DEBUG.MENU_PROVIDER.HANDLER) {
-			console.log(`[MenuProvider]: closeMenu(${id})`);
+		if (isMenuOpen(id)) {
+			if (DEBUG.MENU_PROVIDER.HANDLER) {
+				console.log(`[MenuProvider]: closeMenu(${id})`);
+			}
+			setOpenMenus((prevState) =>
+				prevState.filter((menu) => menu.id !== id)
+			);
 		}
-		setOpenMenus((prevState) => prevState.filter((menu) => menu.id !== id));
 	};
 
 	function handleClick(e: React.MouseEvent) {

--- a/src/app/components/MenuProvider/index.tsx
+++ b/src/app/components/MenuProvider/index.tsx
@@ -10,8 +10,21 @@ interface IMenuContext {
 
 const MenuContext = React.createContext<IMenuContext>({});
 
-export const useMenu = () => {
-	return useContext(MenuContext);
+export const useMenu = (id: string, level: number) => {
+	const { openMenu, closeMenu, isMenuOpen } = useContext(MenuContext);
+
+	function open(id: string, level: number) {
+		openMenu(id, level);
+	}
+
+	function close(id: string) {
+		closeMenu(id);
+	}
+	return {
+		isOpen: isMenuOpen(id),
+		open: () => open(id, level),
+		close: () => close(id),
+	};
 };
 
 interface Props {

--- a/src/app/components/MenuProvider/index.tsx
+++ b/src/app/components/MenuProvider/index.tsx
@@ -72,7 +72,6 @@ export default function MenuProvider({ children }: Props) {
 	};
 
 	function handleClick(e: React.MouseEvent) {
-		console.log("MENU PROVIDER CLICK");
 		if (isFocused && openMenus.length !== 0) {
 			if (e.target instanceof HTMLElement) {
 				let el = e.target;
@@ -80,7 +79,8 @@ export default function MenuProvider({ children }: Props) {
 				while (el.id === "" && el.className !== "NLT__app") {
 					el = el.parentElement;
 				}
-				//Close top level
+				//This will close top level on outside click, closing besides any other
+				//click is left up to specific menu
 				const topMenu = findTopMenu();
 				if (el.id !== topMenu.id) closeMenu(topMenu.id);
 			}

--- a/src/app/components/MenuProvider/index.tsx
+++ b/src/app/components/MenuProvider/index.tsx
@@ -13,17 +13,10 @@ const MenuContext = React.createContext<IMenuContext>({});
 export const useMenu = (id: string, level: number) => {
 	const { openMenu, closeMenu, isMenuOpen } = useContext(MenuContext);
 
-	function open(id: string, level: number) {
-		openMenu(id, level);
-	}
-
-	function close(id: string) {
-		closeMenu(id);
-	}
 	return {
-		isOpen: isMenuOpen(id),
-		open: () => open(id, level),
-		close: () => close(id),
+		isMenuOpen: isMenuOpen(id),
+		openMenu: () => openMenu(id, level),
+		closeMenu: () => closeMenu(id),
 	};
 };
 
@@ -46,7 +39,8 @@ export default function MenuProvider({ children }: Props) {
 	}
 
 	function isMenuOpen(id: string): boolean {
-		return openMenus.find((menu) => menu.id === id) || false;
+		if (openMenus.find((menu) => menu.id === id)) return true;
+		return false;
 	}
 
 	function closeAllMenus() {

--- a/src/app/components/MenuProvider/index.tsx
+++ b/src/app/components/MenuProvider/index.tsx
@@ -52,12 +52,12 @@ export default function MenuProvider({ children }: Props) {
 		return false;
 	}
 
-	// function closeAllMenus() {
-	// 	if (DEBUG.MENU_PROVIDER.HANDLER) {
-	// 		console.log("[MenuProvider]: closeAllMenus()");
-	// 	}
-	// 	setOpenMenus([]);
-	// }
+	function closeAllMenus() {
+		if (DEBUG.MENU_PROVIDER.HANDLER) {
+			console.log("[MenuProvider]: closeAllMenus()");
+		}
+		setOpenMenus([]);
+	}
 
 	const closeMenu = (id: string) => {
 		if (isMenuOpen(id)) {
@@ -112,12 +112,16 @@ export default function MenuProvider({ children }: Props) {
 		return topMenu;
 	}
 
-	// useEffect(() => {
-	// 	if (!isFocused) closeAllMenus();
-	// }, [isFocused]);
+	useEffect(() => {
+		if (!isFocused) closeAllMenus();
+	}, [isFocused]);
 
 	return (
-		<div onClick={handleClick} onKeyUp={handleKeyUp}>
+		<div
+			onMouseDown={(e) => e.preventDefault()}
+			onClick={handleClick}
+			onKeyUp={handleKeyUp}
+		>
 			<MenuContext.Provider
 				value={{
 					isMenuOpen,

--- a/src/app/components/NumberCellEdit/index.tsx
+++ b/src/app/components/NumberCellEdit/index.tsx
@@ -7,7 +7,7 @@ interface Props {
 	isOpen: boolean;
 	top: number;
 	left: number;
-	width: string;
+	width: number;
 	inputText: string;
 	onInputChange: (value: string) => void;
 }

--- a/src/app/components/RowMenu/index.tsx
+++ b/src/app/components/RowMenu/index.tsx
@@ -10,6 +10,7 @@ import "./styles.css";
 import { DRAG_MENU_ITEM } from "./constants";
 import { ICON, MENU_LEVEL } from "src/app/constants";
 import { useMenu } from "../MenuProvider";
+import { useResizeTime } from "src/app/services/hooks";
 interface Props {
 	rowId: string;
 	isFirstRow: boolean;
@@ -29,7 +30,7 @@ export default function RowMenu({
 }: Props) {
 	const [menuId] = useState(uuidv4());
 	const [buttonId] = useState(uuidv4());
-	const [resizeTime, setResizeTime] = useState(0);
+	const resizeTime = useResizeTime();
 	const [menuPosition, setMenuPosition] = useState({
 		top: 0,
 		left: 0,
@@ -44,28 +45,13 @@ export default function RowMenu({
 						node.getBoundingClientRect();
 					setMenuPosition({
 						top: top + height,
-						left: left - width - 60,
+						left: left - width - 65,
 					});
 				}
 			}
 		},
-		[isOpen, resizeTime]
+		[resizeTime, isOpen]
 	);
-
-	useEffect(() => {
-		function handleResize() {
-			console.log("RESIZING");
-			setResizeTime(Date.now());
-		}
-
-		setTimeout(() => {
-			const el = document.getElementsByClassName("view-content")[0];
-			if (el) {
-				new ResizeObserver(handleResize).observe(el);
-				handleResize();
-			}
-		}, 1);
-	}, []);
 
 	function handleButtonClick(e: React.MouseEvent) {
 		if (isOpen) return;

--- a/src/app/components/RowMenu/index.tsx
+++ b/src/app/components/RowMenu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 import IconButton from "../IconButton";
@@ -9,8 +9,8 @@ import RowMenuItem from "./components/RowMenuItem";
 import "./styles.css";
 import { DRAG_MENU_ITEM } from "./constants";
 import { ICON, MENU_LEVEL } from "src/app/constants";
-import { useMenu } from "../MenuProvider";
-import { useDisableScroll, useResizeTime } from "src/app/services/hooks";
+import { useMenuRef } from "src/app/services/hooks";
+import { useDisableScroll, useMenuId } from "src/app/services/hooks";
 interface Props {
 	rowId: string;
 	isFirstRow: boolean;
@@ -28,54 +28,34 @@ export default function RowMenu({
 	onDeleteClick,
 	onInsertRowClick,
 }: Props) {
-	const [menuId] = useState(uuidv4());
 	const [buttonId] = useState(uuidv4());
-	const resizeTime = useResizeTime();
-	const [menuPosition, setMenuPosition] = useState({
-		top: 0,
-		left: 0,
-	});
-	const { isOpen, open, close } = useMenu(menuId, MENU_LEVEL.ONE);
-	useDisableScroll(isOpen);
+	const menuId = useMenuId();
+	const { menuPosition, menuRef, isMenuOpen, openMenu, closeMenu } =
+		useMenuRef(menuId, MENU_LEVEL.ONE);
 
-	const divRef = useCallback(
-		(node) => {
-			if (node) {
-				if (node instanceof HTMLElement) {
-					const { top, left, width, height } =
-						node.getBoundingClientRect();
-					setMenuPosition({
-						top: top + height,
-						left: left - width - 65,
-					});
-				}
-			}
-		},
-		[resizeTime, isOpen]
-	);
+	useDisableScroll(isMenuOpen);
 
 	function handleButtonClick(e: React.MouseEvent) {
-		if (isOpen) return;
-		open();
+		openMenu();
 	}
 
 	function handleDeleteClick(id: string) {
 		onDeleteClick(id);
-		close();
+		closeMenu();
 	}
 
 	function handleInsertRowClick(id: string, insertBelow: boolean) {
 		onInsertRowClick(id, insertBelow);
-		close();
+		closeMenu();
 	}
 
 	function handleMoveRowClick(id: string, moveBelow: boolean) {
 		onMoveRowClick(id, moveBelow);
-		close();
+		closeMenu();
 	}
 
 	return (
-		<div ref={divRef}>
+		<div ref={menuRef}>
 			<IconButton
 				id={buttonId}
 				icon={ICON.MORE_VERT}
@@ -83,9 +63,9 @@ export default function RowMenu({
 			/>
 			<Menu
 				id={menuId}
-				isOpen={isOpen}
-				top={menuPosition.top}
-				left={menuPosition.left}
+				isOpen={isMenuOpen}
+				top={menuPosition.top + menuPosition.height}
+				left={menuPosition.left - menuPosition.width - 65}
 			>
 				<div className="NLT__drag-menu">
 					{Object.values(DRAG_MENU_ITEM).map((item) => {

--- a/src/app/components/RowMenu/index.tsx
+++ b/src/app/components/RowMenu/index.tsx
@@ -10,7 +10,7 @@ import "./styles.css";
 import { DRAG_MENU_ITEM } from "./constants";
 import { ICON, MENU_LEVEL } from "src/app/constants";
 import { useMenu } from "../MenuProvider";
-import { useResizeTime } from "src/app/services/hooks";
+import { useDisableScroll, useResizeTime } from "src/app/services/hooks";
 interface Props {
 	rowId: string;
 	isFirstRow: boolean;
@@ -36,6 +36,7 @@ export default function RowMenu({
 		left: 0,
 	});
 	const { isOpen, open, close } = useMenu(menuId, MENU_LEVEL.ONE);
+	useDisableScroll(isOpen);
 
 	const divRef = useCallback(
 		(node) => {

--- a/src/app/components/RowMenu/index.tsx
+++ b/src/app/components/RowMenu/index.tsx
@@ -34,26 +34,26 @@ export default function RowMenu({
 		top: 0,
 		left: 0,
 	});
-	const { isMenuOpen, openMenu, closeMenu } = useMenu();
+	const { isOpen, open, close } = useMenu(menuId, MENU_LEVEL.ONE);
 
 	function handleButtonClick(e: React.MouseEvent) {
-		if (isMenuOpen(menuId)) return;
-		openMenu(menuId, MENU_LEVEL.ONE);
+		if (isOpen) return;
+		open();
 	}
 
 	function handleDeleteClick(id: string) {
 		onDeleteClick(id);
-		closeMenu(menuId);
+		close();
 	}
 
 	function handleInsertRowClick(id: string, insertBelow: boolean) {
 		onInsertRowClick(id, insertBelow);
-		closeMenu(menuId);
+		close();
 	}
 
 	function handleMoveRowClick(id: string, moveBelow: boolean) {
 		onMoveRowClick(id, moveBelow);
-		closeMenu(menuId);
+		close();
 	}
 
 	const divRef = useCallback(
@@ -71,7 +71,7 @@ export default function RowMenu({
 				}
 			}
 		},
-		[isMenuOpen(menuId)]
+		[isOpen]
 	);
 
 	return (
@@ -83,7 +83,7 @@ export default function RowMenu({
 			/>
 			<Menu
 				id={menuId}
-				isOpen={isMenuOpen(menuId)}
+				isOpen={isOpen}
 				top={menuPosition.top}
 				left={menuPosition.left}
 			>

--- a/src/app/components/RowMenu/index.tsx
+++ b/src/app/components/RowMenu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 import IconButton from "../IconButton";
@@ -36,6 +36,37 @@ export default function RowMenu({
 	});
 	const { isOpen, open, close } = useMenu(menuId, MENU_LEVEL.ONE);
 
+	const divRef = useCallback(
+		(node) => {
+			if (node) {
+				if (node instanceof HTMLElement) {
+					const { top, left, width, height } =
+						node.getBoundingClientRect();
+					setMenuPosition({
+						top: top + height,
+						left: left - width - 60,
+					});
+				}
+			}
+		},
+		[isOpen, resizeTime]
+	);
+
+	useEffect(() => {
+		function handleResize() {
+			console.log("RESIZING");
+			setResizeTime(Date.now());
+		}
+
+		setTimeout(() => {
+			const el = document.getElementsByClassName("view-content")[0];
+			if (el) {
+				new ResizeObserver(handleResize).observe(el);
+				handleResize();
+			}
+		}, 1);
+	}, []);
+
 	function handleButtonClick(e: React.MouseEvent) {
 		if (isOpen) return;
 		open();
@@ -55,24 +86,6 @@ export default function RowMenu({
 		onMoveRowClick(id, moveBelow);
 		close();
 	}
-
-	const divRef = useCallback(
-		(node) => {
-			if (node) {
-				if (node instanceof HTMLElement) {
-					setTimeout(() => {
-						const { top, left, width, height } =
-							node.getBoundingClientRect();
-						setMenuPosition({
-							top: top + height,
-							left: left - width - 60,
-						});
-					}, 1);
-				}
-			}
-		},
-		[isOpen]
-	);
 
 	return (
 		<div ref={divRef}>

--- a/src/app/components/RowMenu/index.tsx
+++ b/src/app/components/RowMenu/index.tsx
@@ -30,21 +30,13 @@ export default function RowMenu({
 }: Props) {
 	const [buttonId] = useState(uuidv4());
 	const menuId = useMenuId();
-	const {
-		menuPosition,
-		menuRef,
-		isMenuOpen,
-		openMenu,
-		closeMenu,
-		canOpenMenu,
-	} = useMenuRef(menuId, MENU_LEVEL.ONE);
+	const { menuPosition, menuRef, isMenuOpen, openMenu, closeMenu } =
+		useMenuRef(menuId, MENU_LEVEL.ONE);
 
 	useDisableScroll(isMenuOpen);
 
 	function handleButtonClick(e: React.MouseEvent) {
-		if (canOpenMenu()) {
-			openMenu();
-		}
+		openMenu();
 	}
 
 	function handleDeleteClick(id: string) {

--- a/src/app/components/RowMenu/index.tsx
+++ b/src/app/components/RowMenu/index.tsx
@@ -30,13 +30,21 @@ export default function RowMenu({
 }: Props) {
 	const [buttonId] = useState(uuidv4());
 	const menuId = useMenuId();
-	const { menuPosition, menuRef, isMenuOpen, openMenu, closeMenu } =
-		useMenuRef(menuId, MENU_LEVEL.ONE);
+	const {
+		menuPosition,
+		menuRef,
+		isMenuOpen,
+		openMenu,
+		closeMenu,
+		canOpenMenu,
+	} = useMenuRef(menuId, MENU_LEVEL.ONE);
 
 	useDisableScroll(isMenuOpen);
 
 	function handleButtonClick(e: React.MouseEvent) {
-		openMenu();
+		if (canOpenMenu()) {
+			openMenu();
+		}
 	}
 
 	function handleDeleteClick(id: string) {

--- a/src/app/components/TagCell/index.tsx
+++ b/src/app/components/TagCell/index.tsx
@@ -34,7 +34,6 @@ export default function TagCell({
 	isCreate,
 	showLink = false,
 	onRemoveClick,
-	onClick,
 }: Props) {
 	let tagClass = "NLT__tag";
 	tagClass += " " + findColorClass(color);
@@ -50,26 +49,14 @@ export default function TagCell({
 	}
 
 	return (
-		<div
-			className={cellClass}
-			style={style}
-			onClick={(e) => {
-				//If we're showing a link, that means we're rendering a tag
-				//and we want event propagation since the cell has an on click handler.
-				//Otherwise turn off, as without this code the cell menu will not close upon
-				//tag click
-				if (!showLink) e.stopPropagation();
-				onClick && onClick(id);
-			}}
-		>
+		<div className={cellClass} style={style}>
 			{isCreate && <div>Create&nbsp;</div>}
 			<div className={tagClass}>
 				<div className="NLT__tag-content">{parse(content)}</div>
 				{showRemove && (
 					<CloseIcon
 						className="NLT__icon--md NLT__margin-left NLT__icon--selectable"
-						onClick={(e) => {
-							e.stopPropagation();
+						onClick={() => {
 							onRemoveClick(cellId, id);
 						}}
 					/>

--- a/src/app/components/TagCell/index.tsx
+++ b/src/app/components/TagCell/index.tsx
@@ -56,7 +56,8 @@ export default function TagCell({
 				{showRemove && (
 					<CloseIcon
 						className="NLT__icon--md NLT__margin-left NLT__icon--selectable"
-						onClick={() => {
+						onClick={(e) => {
+							e.stopPropagation();
 							onRemoveClick(cellId, id);
 						}}
 					/>

--- a/src/app/components/TagCellEdit/component/CreateTag/index.tsx
+++ b/src/app/components/TagCellEdit/component/CreateTag/index.tsx
@@ -13,7 +13,9 @@ export default function CreateTag({ content, color, onAddTag }: Props) {
 	return (
 		<div
 			className="NLT__create-tag NLT__selectable"
-			onClick={() => onAddTag(content)}
+			onClick={() => {
+				onAddTag(content);
+			}}
 		>
 			<div>Create&nbsp;</div>
 			<TagCell content={content} color={color} hideLink={true} />

--- a/src/app/components/TagCellEdit/component/SelectableTag/index.tsx
+++ b/src/app/components/TagCellEdit/component/SelectableTag/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 
 import parse from "html-react-parser";
 
@@ -11,6 +11,7 @@ import "./styles.css";
 import IconButton from "src/app/components/IconButton";
 import TagColorMenu from "src/app/components/TagColorMenu";
 import { useMenu } from "src/app/components/MenuProvider";
+import { useResizeTime } from "src/app/services/hooks";
 interface Props {
 	id: string;
 	content: string;
@@ -26,10 +27,25 @@ export default function SelectableTag({
 	onClick,
 	onColorChange,
 }: Props) {
+	const [menuPosition, setMenuPosition] = useState({
+		top: 0,
+		left: 0,
+	});
 	const [menuId] = useState(uuidv4());
 	const { isOpen, open, close } = useMenu(menuId, MENU_LEVEL.TWO);
+	const resizeTime = useResizeTime();
 	let tagClass = "NLT__tag";
 	tagClass += " " + findColorClass(color);
+
+	const divRef = useCallback(
+		(node) => {
+			if (node instanceof HTMLElement) {
+				const { top, left } = node.getBoundingClientRect();
+				setMenuPosition({ top, left });
+			}
+		},
+		[isOpen, resizeTime]
+	);
 
 	function handleColorChange(color: string) {
 		onColorChange(id, color);
@@ -37,6 +53,7 @@ export default function SelectableTag({
 	}
 	return (
 		<div
+			ref={divRef}
 			className="NLT__selectable-tag NLT__selectable"
 			onClick={() => onClick(id)}
 		>
@@ -54,8 +71,8 @@ export default function SelectableTag({
 				menuId={menuId}
 				isOpen={isOpen}
 				selectedColor={color}
-				top={-100}
-				left={-120}
+				top={menuPosition.top - 77}
+				left={menuPosition.left + 110}
 				onColorClick={(color) => handleColorChange(color)}
 			/>
 		</div>

--- a/src/app/components/TagCellEdit/component/SelectableTag/index.tsx
+++ b/src/app/components/TagCellEdit/component/SelectableTag/index.tsx
@@ -1,8 +1,6 @@
-import React, { useState, useCallback } from "react";
+import React from "react";
 
 import parse from "html-react-parser";
-
-import { v4 as uuidv4 } from "uuid";
 
 import { findColorClass } from "src/app/services/color";
 
@@ -10,8 +8,8 @@ import { ICON, MENU_LEVEL } from "src/app/constants";
 import "./styles.css";
 import IconButton from "src/app/components/IconButton";
 import TagColorMenu from "src/app/components/TagColorMenu";
-import { useMenu } from "src/app/components/MenuProvider";
-import { useResizeTime } from "src/app/services/hooks";
+import { useMenuId, useMenuRef } from "src/app/services/hooks";
+
 interface Props {
 	id: string;
 	content: string;
@@ -27,33 +25,20 @@ export default function SelectableTag({
 	onClick,
 	onColorChange,
 }: Props) {
-	const [menuPosition, setMenuPosition] = useState({
-		top: 0,
-		left: 0,
-	});
-	const [menuId] = useState(uuidv4());
-	const { isOpen, open, close } = useMenu(menuId, MENU_LEVEL.TWO);
-	const resizeTime = useResizeTime();
-	let tagClass = "NLT__tag";
-	tagClass += " " + findColorClass(color);
-
-	const divRef = useCallback(
-		(node) => {
-			if (node instanceof HTMLElement) {
-				const { top, left } = node.getBoundingClientRect();
-				setMenuPosition({ top, left });
-			}
-		},
-		[isOpen, resizeTime]
-	);
+	const menuId = useMenuId();
+	const { menuPosition, menuRef, isMenuOpen, openMenu, closeMenu } =
+		useMenuRef(menuId, MENU_LEVEL.TWO);
 
 	function handleColorChange(color: string) {
 		onColorChange(id, color);
-		close();
+		closeMenu();
 	}
+
+	let tagClass = "NLT__tag";
+	tagClass += " " + findColorClass(color);
 	return (
 		<div
-			ref={divRef}
+			ref={menuRef}
 			className="NLT__selectable-tag NLT__selectable"
 			onClick={() => onClick(id)}
 		>
@@ -64,12 +49,12 @@ export default function SelectableTag({
 				icon={ICON.MORE_HORIZ}
 				onClick={(e) => {
 					e.stopPropagation();
-					open();
+					openMenu();
 				}}
 			/>
 			<TagColorMenu
 				menuId={menuId}
-				isOpen={isOpen}
+				isOpen={isMenuOpen}
 				selectedColor={color}
 				top={menuPosition.top - 77}
 				left={menuPosition.left + 110}

--- a/src/app/components/TagCellEdit/component/SelectableTag/index.tsx
+++ b/src/app/components/TagCellEdit/component/SelectableTag/index.tsx
@@ -48,6 +48,7 @@ export default function SelectableTag({
 			<IconButton
 				icon={ICON.MORE_HORIZ}
 				onClick={(e) => {
+					//Why does this close it??
 					e.stopPropagation();
 					openMenu();
 				}}

--- a/src/app/components/TagCellEdit/component/SelectableTag/index.tsx
+++ b/src/app/components/TagCellEdit/component/SelectableTag/index.tsx
@@ -26,14 +26,14 @@ export default function SelectableTag({
 	onClick,
 	onColorChange,
 }: Props) {
-	const { openMenu, closeMenu, isMenuOpen } = useMenu();
 	const [menuId] = useState(uuidv4());
+	const { isOpen, open, close } = useMenu(menuId, MENU_LEVEL.TWO);
 	let tagClass = "NLT__tag";
 	tagClass += " " + findColorClass(color);
 
 	function handleColorChange(color: string) {
 		onColorChange(id, color);
-		closeMenu(menuId);
+		close();
 	}
 	return (
 		<div
@@ -47,12 +47,12 @@ export default function SelectableTag({
 				icon={ICON.MORE_HORIZ}
 				onClick={(e) => {
 					e.stopPropagation();
-					openMenu(menuId, MENU_LEVEL.TWO);
+					open();
 				}}
 			/>
 			<TagColorMenu
 				menuId={menuId}
-				isOpen={isMenuOpen(menuId)}
+				isOpen={isOpen}
 				selectedColor={color}
 				top={-100}
 				left={-120}

--- a/src/app/components/TagCellEdit/component/SelectableTag/index.tsx
+++ b/src/app/components/TagCellEdit/component/SelectableTag/index.tsx
@@ -48,7 +48,8 @@ export default function SelectableTag({
 			<IconButton
 				icon={ICON.MORE_HORIZ}
 				onClick={(e) => {
-					//Why does this close it??
+					//Stop propagation so we don't call the onClick handler
+					//on this div
 					e.stopPropagation();
 					openMenu();
 				}}

--- a/src/app/components/TagCellEdit/index.tsx
+++ b/src/app/components/TagCellEdit/index.tsx
@@ -40,21 +40,6 @@ export default function TagCellEdit({
 	onColorChange,
 	onRemoveTagClick,
 }: Props) {
-	const inputRef = useCallback(
-		(node) => {
-			if (node) {
-				if (node instanceof HTMLElement) {
-					if (isOpen) {
-						setTimeout(() => {
-							node.focus();
-						}, 1);
-					}
-				}
-			}
-		},
-		[isOpen]
-	);
-
 	function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
 		//Disallow whitespace
 		if (e.target.value.match(/\s/)) return;
@@ -114,7 +99,7 @@ export default function TagCellEdit({
 							))}
 						<input
 							className="NLT__tag-input"
-							ref={inputRef}
+							autoFocus={true}
 							type="text"
 							value={inputText}
 							onChange={handleTextChange}

--- a/src/app/components/TagColorMenu/components/ColorItem/index.tsx
+++ b/src/app/components/TagColorMenu/components/ColorItem/index.tsx
@@ -22,7 +22,8 @@ export default function ColorItem({ color, isSelected, onColorClick }: Props) {
 		<div
 			className={containerClass}
 			onClick={(e) => {
-				//Stop event propagation so we don't select this cell
+				//Stop event propagation so we don't select the tag menu
+				//and close it
 				e.stopPropagation();
 				onColorClick(color);
 			}}

--- a/src/app/components/TextCellEdit/index.tsx
+++ b/src/app/components/TextCellEdit/index.tsx
@@ -9,7 +9,7 @@ interface Props {
 	isOpen: boolean;
 	top: number;
 	left: number;
-	width: string;
+	width: number;
 	inputText: string;
 	onInputChange: (value: string) => void;
 }
@@ -53,7 +53,7 @@ export default function TextCellEdit({
 			top={top}
 			left={left}
 			width={width}
-			height={`${height}px`}
+			height={height}
 		>
 			<textarea
 				className="NLT__textarea"

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -17,12 +17,12 @@ export const DEBUG = {
 		USE_EFFECT: false,
 	},
 	FOCUS_PROVIDER: {
-		HANDLER: false,
-		USE_EFFECT: false,
+		HANDLER: true,
+		USE_EFFECT: true,
 	},
 	MENU_PROVIDER: {
-		HANDLER: false,
-		USE_EFFECT: false,
+		HANDLER: true,
+		USE_EFFECT: true,
 	},
 };
 

--- a/src/app/services/hooks/index.ts
+++ b/src/app/services/hooks/index.ts
@@ -1,6 +1,25 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, useEffect } from "react";
 
 export const useForceUpdate = () => {
 	const [, setValue] = useState(0);
 	return useCallback(() => setValue((value) => value + 1), []);
+};
+
+export const useResizeTime = () => {
+	const [resizeTime, setResizeTime] = useState(0);
+
+	useEffect(() => {
+		function handleResize() {
+			setResizeTime(Date.now());
+		}
+
+		setTimeout(() => {
+			const el = document.getElementsByClassName("view-content")[0];
+			if (el) {
+				new ResizeObserver(handleResize).observe(el);
+				handleResize();
+			}
+		}, 1);
+	}, []);
+	return resizeTime;
 };

--- a/src/app/services/hooks/index.ts
+++ b/src/app/services/hooks/index.ts
@@ -32,10 +32,7 @@ export const useMenuRef = (menuId: string, menuLevel: number) => {
 	});
 	const [shouldOpenMenu, setOpenMenu] = useState(false);
 	const resizeTime = useResizeTime();
-	const { isMenuOpen, openMenu, closeMenu, canOpenMenu } = useMenu(
-		menuId,
-		menuLevel
-	);
+	const { isMenuOpen, openMenu, closeMenu } = useMenu(menuId, menuLevel);
 
 	//Only open the menu after the position has been updated
 	useEffect(() => {
@@ -61,7 +58,6 @@ export const useMenuRef = (menuId: string, menuLevel: number) => {
 		menuPosition,
 		openMenu: () => setOpenMenu(true),
 		closeMenu,
-		canOpenMenu: () => canOpenMenu(menuLevel),
 		isMenuOpen,
 		menuRef,
 	};

--- a/src/app/services/hooks/index.ts
+++ b/src/app/services/hooks/index.ts
@@ -1,8 +1,70 @@
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useState, useEffect, useRef } from "react";
 
 export const useForceUpdate = () => {
 	const [, setValue] = useState(0);
 	return useCallback(() => setValue((value) => value + 1), []);
+};
+
+export const useDisableScroll = (isOpen: boolean) => {
+	const scroll = useRef({
+		top: 0,
+		left: 0,
+	});
+
+	const el = document.getElementsByClassName("NLT__app")[0];
+
+	function handleScroll() {
+		if (el) {
+			const { top, left } = scroll.current;
+			el.scrollTo(left, top);
+		}
+	}
+	useEffect(() => {
+		if (el instanceof HTMLElement) {
+			if (isOpen) {
+				scroll.current = {
+					top: el.scrollTop,
+					left: el.scrollLeft,
+				};
+				el.addEventListener("scroll", handleScroll);
+			} else {
+				el.removeEventListener("scroll", handleScroll);
+			}
+		}
+
+		return () => {
+			if (el) {
+				el.removeEventListener("scroll", handleScroll);
+			}
+		};
+	}, [isOpen]);
+};
+
+export const useScrollTime = () => {
+	const [scrollTime, setScrollTime] = useState(0);
+
+	useEffect(() => {
+		function handleScroll() {
+			setScrollTime(Date.now());
+		}
+
+		let el: any = null;
+
+		setTimeout(() => {
+			el = document.getElementsByClassName("NLT__app")[0];
+			if (el) {
+				el.addEventListener("scroll", handleScroll);
+			}
+		}, 1);
+
+		return () => {
+			if (el) {
+				el.removeEventListener("scroll", handleScroll);
+			}
+		};
+	}, []);
+	console.log(scrollTime);
+	return scrollTime;
 };
 
 export const useResizeTime = () => {

--- a/src/app/services/hooks/index.ts
+++ b/src/app/services/hooks/index.ts
@@ -32,7 +32,10 @@ export const useMenuRef = (menuId: string, menuLevel: number) => {
 	});
 	const [shouldOpenMenu, setOpenMenu] = useState(false);
 	const resizeTime = useResizeTime();
-	const { isMenuOpen, openMenu, closeMenu } = useMenu(menuId, menuLevel);
+	const { isMenuOpen, openMenu, closeMenu, canOpenMenu } = useMenu(
+		menuId,
+		menuLevel
+	);
 
 	//Only open the menu after the position has been updated
 	useEffect(() => {
@@ -58,6 +61,7 @@ export const useMenuRef = (menuId: string, menuLevel: number) => {
 		menuPosition,
 		openMenu: () => setOpenMenu(true),
 		closeMenu,
+		canOpenMenu: () => canOpenMenu(menuLevel),
 		isMenuOpen,
 		menuRef,
 	};


### PR DESCRIPTION
- Fixed #184. Tag menus now open.
- Fixed #181. NLT__app container cannot be scrollable when a menu is open
- Fixed #164. Menu position will update on resize/open.
- Refactored menu system. Added a `useMenuRef` to make menu opening synchronous.
- Level 1 menus will now close on outside click without opening another menu.