### PR TITLE
Bug/default sort

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -114,17 +114,6 @@
 	background-color: var(--interactive-normal);
 }
 
-/*
-* Margin
-*/
-.NLT__margin-right {
-	margin-right: 4px;
-}
-
-.NLT__margin-left {
-	margin-left: 4px;
-}
-
 /**
 * Overflow
 */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,4 +19,4 @@ export const COLOR: { [color: string]: string } = {
 	RED: "red",
 };
 
-export const CURRENT_TABLE_CACHE_VERSION = 500;
+export const CURRENT_PLUGIN_VERSION = 500;

--- a/src/main.ts
+++ b/src/main.ts
@@ -275,12 +275,8 @@ export default class NltPlugin extends Plugin {
 			callback: async () => {
 				if (this.focusedTableId) {
 					const tableId = this.focusedTableId;
-					const { model } = this.settings.data[tableId];
-					const updatedModel = addRow(model);
-					const newState = {
-						...this.settings.data[tableId],
-						model: updatedModel,
-					};
+					const prevState = this.settings.data[tableId];
+					const newState = addRow(prevState);
 					const viewModesToUpdate: MarkdownViewModeType[] = [
 						"preview",
 					];

--- a/src/services/mock/index.ts
+++ b/src/services/mock/index.ts
@@ -3,6 +3,8 @@ import {
 	DEFAULT_COLUMN_SETTINGS,
 	TableState,
 	ColumnSettings,
+	RowSettings,
+	DEFAULT_ROW_SETTINGS,
 } from "../table/types";
 
 const tableHeaderRow = (numColumns: number) => {
@@ -76,13 +78,18 @@ export const mockMarkdownTable = (
 	return table;
 };
 
-export const mockSettings = (numColumns: number) => {
+export const mockSettings = (numColumns: number, numRows: number) => {
 	const columns: { [x: string]: ColumnSettings } = {};
+	const rows: { [x: string]: RowSettings } = {};
 	for (let i = 0; i < numColumns; i++) {
-		columns[i] = DEFAULT_COLUMN_SETTINGS;
+		columns[i] = { ...DEFAULT_COLUMN_SETTINGS };
+	}
+	for (let i = 0; i < numRows; i++) {
+		rows[i] = { ...DEFAULT_ROW_SETTINGS };
 	}
 	return {
 		columns,
+		rows,
 	};
 };
 
@@ -111,7 +118,12 @@ export const mockTableState = (
 	}
 	const columnSettings = Object.fromEntries(
 		columnIds.map((id) => {
-			return [id, DEFAULT_COLUMN_SETTINGS];
+			return [id, { ...DEFAULT_COLUMN_SETTINGS }];
+		})
+	);
+	const rowSettings = Object.fromEntries(
+		rowIds.map((id) => {
+			return [id, DEFAULT_ROW_SETTINGS];
 		})
 	);
 	return {
@@ -120,9 +132,10 @@ export const mockTableState = (
 			columnIds,
 			cells,
 		},
-		cacheVersion: 1,
+		pluginVersion: 1,
 		settings: {
 			columns: columnSettings,
+			rows: rowSettings,
 		},
 	};
 };

--- a/src/services/sort/sort.ts
+++ b/src/services/sort/sort.ts
@@ -31,8 +31,6 @@ export const sortRows = (prevState: TableState): TableModel => {
 
 		const markdownA = cellA.markdown;
 		const markdownB = cellB.markdown;
-		console.log("A", markdownA);
-		console.log("B", markdownB);
 
 		//Force empty cells to the bottom
 		if (cellA.isHeader) return -1;
@@ -47,8 +45,6 @@ export const sortRows = (prevState: TableState): TableModel => {
 			return markdownB.localeCompare(markdownA);
 		}
 	});
-
-	console.log(updatedRows);
 
 	return {
 		rowIds: updatedRows,

--- a/src/services/table/column.ts
+++ b/src/services/table/column.ts
@@ -49,7 +49,7 @@ export const addColumn = (
 			...prevState.settings,
 			columns: {
 				...prevState.settings.columns,
-				[columnId]: DEFAULT_COLUMN_SETTINGS,
+				[columnId]: { ...DEFAULT_COLUMN_SETTINGS },
 			},
 		},
 	];

--- a/src/services/table/row.ts
+++ b/src/services/table/row.ts
@@ -1,17 +1,15 @@
-import { TableModel } from "./types";
+import { DEFAULT_ROW_SETTINGS, TableState } from "./types";
 
 import { randomCellId, randomRowId } from "../random";
 
-export const addRow = (model: TableModel): TableModel => {
-	const { rowIds, columnIds, cells } = model;
-
+export const addRow = (prevState: TableState): TableState => {
 	const rowId = randomRowId();
-	const updatedCells = [...cells];
+	const cellsCopy = [...prevState.model.cells];
 
-	for (let i = 0; i < columnIds.length; i++) {
-		updatedCells.push({
+	for (let i = 0; i < prevState.model.columnIds.length; i++) {
+		cellsCopy.push({
 			id: randomCellId(),
-			columnId: columnIds[i],
+			columnId: prevState.model.columnIds[i],
 			rowId,
 			markdown: "",
 			html: "",
@@ -19,9 +17,20 @@ export const addRow = (model: TableModel): TableModel => {
 		});
 	}
 
+	const settingsCopy = { ...prevState.settings.rows };
+	settingsCopy[rowId] = { ...DEFAULT_ROW_SETTINGS };
+	settingsCopy[rowId].creationDate = Date.now();
+
 	return {
-		...model,
-		cells: updatedCells,
-		rowIds: [...rowIds, rowId],
+		...prevState,
+		model: {
+			...prevState.model,
+			cells: cellsCopy,
+			rowIds: [...prevState.model.rowIds, rowId],
+		},
+		settings: {
+			...prevState.settings,
+			rows: settingsCopy,
+		},
 	};
 };

--- a/src/services/table/types.ts
+++ b/src/services/table/types.ts
@@ -50,6 +50,10 @@ export interface ColumnSettings {
 	tags: Tag[];
 }
 
+export interface RowSettings {
+	creationDate: number;
+}
+
 export const DEFAULT_COLUMN_SETTINGS: ColumnSettings = {
 	sortDir: SortDir.NONE,
 	width: "120px",
@@ -59,14 +63,21 @@ export const DEFAULT_COLUMN_SETTINGS: ColumnSettings = {
 	tags: [],
 };
 
+export const DEFAULT_ROW_SETTINGS: RowSettings = {
+	creationDate: 0,
+};
+
 export interface TableSettings {
 	columns: {
 		[columnId: string]: ColumnSettings;
+	};
+	rows: {
+		[rowId: string]: RowSettings;
 	};
 }
 
 export interface TableState {
 	settings: TableSettings;
 	model: TableModel;
-	cacheVersion: number;
+	pluginVersion: number;
 }


### PR DESCRIPTION
- Refactored: `cacheVersion` to `pluginVersion`
- Added: support for default sort
  - Added a `rows` key to `TableSettings` that accept `RowSettings`
  - Added a `creationDate` key to the `RowSettings` object
  - Refactored sort to use `sortByCreationDate` or `sortByDir`
- Fixed: elusive bug where multiple key were being replaced by the same value
   - This was due to using a direct reference to `DEFAULT_COLUMN_SETTINGS` instead of making a copy `{...DEFAULT_COLUMN_SETTINGS}`