### PR TITLE
Typing bug

### DIFF
--- a/src/react/table-app/currency-cell-edit/index.tsx
+++ b/src/react/table-app/currency-cell-edit/index.tsx
@@ -1,4 +1,4 @@
-import { useFocusMenuInput } from "src/shared/hooks";
+import { useFocusMenuInput, useInputSelection } from "src/shared/hooks";
 import "./styles.css";
 import { isNumber } from "src/shared/validators";
 import { MINUS_REGEX } from "src/shared/regex";
@@ -13,11 +13,20 @@ export default function CurrencyCellEdit({
 	value,
 	onChange,
 }: Props) {
-	const inputRef = useFocusMenuInput(isMenuVisible, value, onChange);
+	const inputRef = useFocusMenuInput(isMenuVisible, value, onChange, {
+		isNumeric: true,
+	});
+
+	const { setPreviousSelectionStart } = useInputSelection(inputRef, value);
 
 	function handleChange(value: string) {
 		if (!isNumber(value) && value !== "" && !value.match(MINUS_REGEX))
 			return;
+		if (inputRef.current) {
+			setPreviousSelectionStart(
+				inputRef.current.selectionStart || value.length
+			);
+		}
 		onChange(value);
 	}
 

--- a/src/react/table-app/currency-cell-edit/index.tsx
+++ b/src/react/table-app/currency-cell-edit/index.tsx
@@ -1,7 +1,7 @@
 import { useFocusMenuInput, useInputSelection } from "src/shared/hooks";
+import { isValidNumberInput } from "src/shared/validators";
+
 import "./styles.css";
-import { isNumber } from "src/shared/validators";
-import { MINUS_REGEX } from "src/shared/regex";
 interface Props {
 	isMenuVisible: boolean;
 	value: string;
@@ -13,28 +13,38 @@ export default function CurrencyCellEdit({
 	value,
 	onChange,
 }: Props) {
-	const inputRef = useFocusMenuInput(isMenuVisible, value, onChange, {
-		isNumeric: true,
-	});
+	const inputRef = useFocusMenuInput(
+		isMenuVisible,
+		value,
+		(value) => handleChange(value, true),
+		{
+			isNumeric: true,
+		}
+	);
 
 	const { setPreviousSelectionStart } = useInputSelection(inputRef, value);
 
-	function handleChange(value: string) {
-		if (!isNumber(value) && value !== "" && !value.match(MINUS_REGEX))
-			return;
+	function handleChange(inputValue: string, setSelectionToLength = false) {
+		if (!isValidNumberInput(inputValue)) return;
+
+		//When we press the menu key, an extra character will be added
+		//we need to update the selection to be after this character
+		//Otherwise keep the selection where it was
 		if (inputRef.current) {
-			setPreviousSelectionStart(
-				inputRef.current.selectionStart || value.length
-			);
+			if (setSelectionToLength) {
+				setPreviousSelectionStart(inputValue.length);
+			} else if (inputRef.current.selectionStart) {
+				setPreviousSelectionStart(inputRef.current.selectionStart);
+			}
 		}
-		onChange(value);
+		onChange(inputValue);
 	}
 
 	return (
 		<div className="NLT__currency-cell-edit">
 			<input
 				ref={inputRef}
-				type="text"
+				type="text" //We use an input of type text so that the selection is available
 				inputMode="numeric"
 				autoFocus
 				value={value}

--- a/src/react/table-app/currency-cell/index.tsx
+++ b/src/react/table-app/currency-cell/index.tsx
@@ -18,12 +18,11 @@ export default function CurrencyCell({
 }: Props) {
 	const overflowClassName = useOverflowClassName(shouldWrapOverflow);
 
-	let valueFormatted = "";
-	if (isNumber(value)) {
-		valueFormatted = stringToCurrencyString(value, currencyType);
-	}
+	let valueString = "";
+	if (isNumber(value))
+		valueString = stringToCurrencyString(value, currencyType);
 
 	const className = "NLT__currency-cell" + " " + overflowClassName;
 
-	return <div className={className}>{valueFormatted}</div>;
+	return <div className={className}>{valueString}</div>;
 }

--- a/src/react/table-app/function-cell/index.tsx
+++ b/src/react/table-app/function-cell/index.tsx
@@ -20,7 +20,7 @@ import { getGeneralFunctionContent } from "./generalFunction";
 
 import "./styles.css";
 import MenuTrigger from "src/react/shared/menu-trigger";
-import { isGeneralFunction } from "src/shared/validators";
+import { isGeneralFunction, isNumber } from "src/shared/validators";
 import { getShortDisplayNameForFunctionType } from "src/shared/table-state/display-name";
 
 interface Props {
@@ -89,7 +89,7 @@ export default function FunctionCell({
 		);
 	} else {
 		const cellValues = columnCells
-			.filter((cell) => cell.markdown !== "")
+			.filter((cell) => isNumber(cell.markdown))
 			.map((cell) => parseFloat(cell.markdown));
 		if (cellValues.length !== 0)
 			content = getNumberFunctionContent(

--- a/src/react/table-app/number-cell-edit/index.tsx
+++ b/src/react/table-app/number-cell-edit/index.tsx
@@ -15,7 +15,7 @@ export default function NumberCellEdit({
 	value,
 	onChange,
 }: Props) {
-	const inputRef = useFocusMenuInput(isMenuVisible, value, onChange, {
+	const inputRef = useFocusMenuInput(isMenuVisible, value, handleChange, {
 		isNumeric: true,
 	});
 	const { setPreviousSelectionStart } = useInputSelection(inputRef, value);

--- a/src/react/table-app/number-cell-edit/index.tsx
+++ b/src/react/table-app/number-cell-edit/index.tsx
@@ -1,8 +1,7 @@
 import { useFocusMenuInput, useInputSelection } from "src/shared/hooks";
-import { isNumber } from "src/shared/validators";
+import { isValidNumberInput } from "src/shared/validators";
 
 import "./styles.css";
-import { MINUS_REGEX } from "src/shared/regex";
 
 interface Props {
 	isMenuVisible: boolean;
@@ -15,20 +14,31 @@ export default function NumberCellEdit({
 	value,
 	onChange,
 }: Props) {
-	const inputRef = useFocusMenuInput(isMenuVisible, value, handleChange, {
-		isNumeric: true,
-	});
+	const inputRef = useFocusMenuInput(
+		isMenuVisible,
+		value,
+		(updatedValue) => handleChange(updatedValue, true),
+		{
+			isNumeric: true,
+		}
+	);
 	const { setPreviousSelectionStart } = useInputSelection(inputRef, value);
 
-	function handleChange(value: string) {
-		if (!isNumber(value) && value !== "" && !value.match(MINUS_REGEX))
-			return;
+	function handleChange(inputValue: string, setSelectionToLength = false) {
+		if (!isValidNumberInput(inputValue)) return;
+
+		//When we press the menu key, an extra character will be added
+		//we need to update the selection to be after this character
+		//Otherwise keep the selection where it was
 		if (inputRef.current) {
-			setPreviousSelectionStart(
-				inputRef.current.selectionStart || value.length
-			);
+			if (setSelectionToLength) {
+				setPreviousSelectionStart(inputValue.length);
+			} else if (inputRef.current.selectionStart) {
+				setPreviousSelectionStart(inputRef.current.selectionStart);
+			}
 		}
-		onChange(value);
+
+		onChange(inputValue);
 	}
 
 	return (

--- a/src/react/table-app/number-cell/index.tsx
+++ b/src/react/table-app/number-cell/index.tsx
@@ -12,10 +12,8 @@ export default function NumberCell({ value, shouldWrapOverflow }: Props) {
 	const overflowClassName = useOverflowClassName(shouldWrapOverflow);
 	const className = "NLT__number-cell" + " " + overflowClassName;
 
-	let valueFormatted = "";
-	if (isNumber(value)) {
-		valueFormatted = value;
-	}
+	let valueString = "";
+	if (isNumber(value)) valueString = value;
 
-	return <div className={className}>{valueFormatted}</div>;
+	return <div className={className}>{valueString}</div>;
 }

--- a/src/react/table-app/text-cell-edit/index.tsx
+++ b/src/react/table-app/text-cell-edit/index.tsx
@@ -22,23 +22,28 @@ export default function TextCellEdit({
 	value,
 	onChange,
 }: Props) {
-	const inputRef = useFocusMenuTextArea(isMenuVisible, value, (value) =>
-		handleTextareaChange(value, true)
+	const inputRef = useFocusMenuTextArea(
+		isMenuVisible,
+		value,
+		(updatedValue) => handleTextareaChange(updatedValue, true)
 	);
 	const { setPreviousSelectionStart } = useInputSelection(inputRef, value);
 
 	function handleTextareaChange(
-		value: string,
-		setSelectionToLength: boolean
+		inputValue: string,
+		setSelectionToLength = false
 	) {
+		//When we press the menu key, an extra character will be added
+		//we need to update the selection to be after this character
+		//Otherwise keep the selection where it was
 		if (inputRef.current) {
 			if (setSelectionToLength) {
-				setPreviousSelectionStart(value.length);
+				setPreviousSelectionStart(inputValue.length);
 			} else {
 				setPreviousSelectionStart(inputRef.current.selectionStart);
 			}
 		}
-		onChange(value);
+		onChange(inputValue);
 	}
 
 	const className = useOverflowClassName(shouldWrapOverflow);
@@ -48,7 +53,7 @@ export default function TextCellEdit({
 				className={className}
 				ref={inputRef}
 				value={value}
-				onChange={(e) => handleTextareaChange(e.target.value, false)}
+				onChange={(e) => handleTextareaChange(e.target.value)}
 			/>
 		</div>
 	);

--- a/src/react/table-app/text-cell-edit/index.tsx
+++ b/src/react/table-app/text-cell-edit/index.tsx
@@ -22,12 +22,21 @@ export default function TextCellEdit({
 	value,
 	onChange,
 }: Props) {
-	const inputRef = useFocusMenuTextArea(isMenuVisible, value, onChange);
+	const inputRef = useFocusMenuTextArea(isMenuVisible, value, (value) =>
+		handleTextareaChange(value, true)
+	);
 	const { setPreviousSelectionStart } = useInputSelection(inputRef, value);
 
-	function handleTextareaChange(value: string) {
+	function handleTextareaChange(
+		value: string,
+		setSelectionToLength: boolean
+	) {
 		if (inputRef.current) {
-			setPreviousSelectionStart(inputRef.current.selectionStart);
+			if (setSelectionToLength) {
+				setPreviousSelectionStart(value.length);
+			} else {
+				setPreviousSelectionStart(inputRef.current.selectionStart);
+			}
 		}
 		onChange(value);
 	}
@@ -39,7 +48,7 @@ export default function TextCellEdit({
 				className={className}
 				ref={inputRef}
 				value={value}
-				onChange={(e) => handleTextareaChange(e.target.value)}
+				onChange={(e) => handleTextareaChange(e.target.value, false)}
 			/>
 		</div>
 	);

--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -41,6 +41,7 @@ export const useInputSelection = (
 	);
 
 	const didValueChange = useCompare(value, true);
+
 	//When the value changes, we want to set the selection to the previous position
 	React.useEffect(() => {
 		function setSelection() {

--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -41,16 +41,16 @@ export const useInputSelection = (
 	);
 
 	const didValueChange = useCompare(value, true);
+	//When the value changes, we want to set the selection to the previous position
 	React.useEffect(() => {
 		function setSelection() {
-			if (didValueChange) {
-				if (inputRef.current) {
-					inputRef.current.selectionStart = previousSelectionStart;
-					inputRef.current.selectionEnd = previousSelectionStart;
-				}
+			if (inputRef.current) {
+				inputRef.current.selectionStart = previousSelectionStart;
+				inputRef.current.selectionEnd = previousSelectionStart;
 			}
 		}
-		if (inputRef.current) setSelection();
+		//Only run when the value changes, not when the previousSelect changes
+		if (didValueChange) setSelection();
 	}, [previousSelectionStart, value, didValueChange]);
 
 	return { setPreviousSelectionStart };

--- a/src/shared/regex.ts
+++ b/src/shared/regex.ts
@@ -1,11 +1,26 @@
 export const TAG_REGEX = new RegExp(/^[#][^\s]+$/);
 
 /**
- * Matches both whole numbers and decimals
+ * Matches a number. The number can be a whole number, a decimal, or a negative number.
+ * @example
+ * 1
+ * @example
+ * 22.05
+ * @example
+ * -5.0
  */
 export const NUMBER_REGEX = new RegExp(/^-?\d+\.?\d*$/);
 
-export const MINUS_REGEX = new RegExp(/^-$/);
+/**
+ * Matches a empty string, a minus sign, or a number
+ * @example
+ * ""
+ * @example
+ * "-"
+ * @example
+ * "-22.05"
+ */
+export const NUMBER_INPUT_REGEX = new RegExp(/(^$)|(^-$)|(^-?\d+\.?\d*$)/);
 
 export const TAGS_REGEX = new RegExp(/#[^ \t]+/g);
 

--- a/src/shared/validators.ts
+++ b/src/shared/validators.ts
@@ -5,10 +5,15 @@ import {
 	DATE_REGEX,
 	CHECKBOX_REGEX,
 	CHECKBOX_CHECKED_REGEX,
+	NUMBER_INPUT_REGEX,
 } from "./regex";
 
 export const isNumber = (input: string): boolean => {
 	return input.match(NUMBER_REGEX) !== null;
+};
+
+export const isValidNumberInput = (input: string): boolean => {
+	return input.match(NUMBER_INPUT_REGEX) !== null;
 };
 
 export const isDate = (input: string): boolean => {


### PR DESCRIPTION
This update will fix bugs relating to opening a menu using a keyboard key and also the cursor position.

**Fixes**
- when pressing a key to open a menu, move cursor to the end of the new value. The new value includes the old value + the pressed menu key
- when editing a value in the currency cell, keep the cursor cell position the same when adding/deleting characters
- when a number cell has a valid value such as a minus `-`, exclude it from the function cell calculation since it is not a number
- prevent any non-numeric menu keys from being appended to the number or currency cell value