### PR TITLE
Plugin version string

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,4 +1,4 @@
-export const CURRENT_PLUGIN_VERSION = 6100;
+export const CURRENT_PLUGIN_VERSION = "6.10.0";
 
 export const DEFAULT_TABLE_NAME = "Untitled";
 

--- a/src/data/serialize-table-state.ts
+++ b/src/data/serialize-table-state.ts
@@ -1,10 +1,8 @@
 import { CURRENT_PLUGIN_VERSION } from "src/data/constants";
 import {
-	BaseTableState,
 	BodyCell,
 	CellType,
 	Column,
-	FilterRule,
 	TableState,
 	Tag,
 } from "../shared/types/types";
@@ -22,6 +20,10 @@ import { CurrencyType610, TableState610 } from "src/shared/types/types-610";
 import { DateFormat620, TableState620 } from "src/shared/types/types-620";
 import { v4 as uuidv4 } from "uuid";
 import { TableState691 } from "src/shared/types/types-691";
+import {
+	isVersionLessThan,
+	legacyVersionToString,
+} from "src/shared/versioning";
 
 export const serializeTableState = (tableState: TableState): string => {
 	return JSON.stringify(tableState, null, 2);
@@ -30,10 +32,18 @@ export const serializeTableState = (tableState: TableState): string => {
 export const deserializeTableState = (data: string): TableState => {
 	const parsedState = JSON.parse(data);
 
-	const { pluginVersion } = parsedState as BaseTableState;
+	const untypedVersion: unknown = parsedState["pluginVersion"];
+
+	let pluginVersion: string = "";
+	if (typeof untypedVersion === "number") {
+		pluginVersion = legacyVersionToString(pluginVersion);
+	} else if (typeof untypedVersion === "string") {
+		pluginVersion = untypedVersion;
+	}
+
 	let currentState: unknown = parsedState;
 
-	if (pluginVersion < 610) {
+	if (isVersionLessThan(pluginVersion, "6.1.0")) {
 		const tableState = currentState as TableState600;
 		const { columns } = tableState.model;
 
@@ -44,7 +54,7 @@ export const deserializeTableState = (data: string): TableState => {
 		});
 	}
 
-	if (pluginVersion < 620) {
+	if (isVersionLessThan(pluginVersion, "6.2.0")) {
 		const tableState = currentState as TableState610;
 		const { columns } = tableState.model;
 
@@ -55,7 +65,7 @@ export const deserializeTableState = (data: string): TableState => {
 		});
 	}
 
-	if (pluginVersion < 630) {
+	if (isVersionLessThan(pluginVersion, "6.3.0")) {
 		const tableState = currentState as TableState620;
 		const { columns, rows, cells } = tableState.model;
 
@@ -88,7 +98,7 @@ export const deserializeTableState = (data: string): TableState => {
 	}
 
 	//Feat: new table state structure
-	if (pluginVersion < 640) {
+	if (isVersionLessThan(pluginVersion, "6.4.0")) {
 		const tableState = parsedState as TableState630;
 		const { columns, tags, rows, cells } = tableState.model;
 
@@ -183,7 +193,7 @@ export const deserializeTableState = (data: string): TableState => {
 	}
 
 	//Feat: filter rules
-	if (pluginVersion < 680) {
+	if (isVersionLessThan(pluginVersion, "6.8.0")) {
 		const tableState = currentState as TableState670;
 		const { model } = tableState;
 		const { bodyCells, columns } = model;
@@ -214,7 +224,7 @@ export const deserializeTableState = (data: string): TableState => {
 		});
 	}
 
-	if (pluginVersion < 691) {
+	if (isVersionLessThan(pluginVersion, "6.9.1")) {
 		const tableState = currentState as TableState680;
 		const { footerCells } = tableState.model;
 
@@ -230,7 +240,7 @@ export const deserializeTableState = (data: string): TableState => {
 	}
 
 	//Feat: support tag sorting
-	if (pluginVersion < 6100) {
+	if (isVersionLessThan(pluginVersion, "6.10.0")) {
 		const tableState = currentState as TableState691;
 		const { columns, tags, bodyCells } = tableState.model;
 

--- a/src/shared/types/types-600.ts
+++ b/src/shared/types/types-600.ts
@@ -1,5 +1,3 @@
-import { BaseTableState } from "./types";
-
 enum Color {
 	LIGHT_GRAY = "light gray",
 	GRAY = "gray",
@@ -69,6 +67,7 @@ interface TableModel {
 	tags: Tag[];
 }
 
-export interface TableState600 extends BaseTableState {
+export interface TableState600 {
+	pluginVersion: string;
 	model: TableModel;
 }

--- a/src/shared/types/types-610.ts
+++ b/src/shared/types/types-610.ts
@@ -1,5 +1,3 @@
-import { BaseTableState } from "./types";
-
 enum Color {
 	LIGHT_GRAY = "light gray",
 	GRAY = "gray",
@@ -90,6 +88,7 @@ interface TableModel {
 	tags: Tag[];
 }
 
-export interface TableState610 extends BaseTableState {
+export interface TableState610 {
+	pluginVersion: string;
 	model: TableModel;
 }

--- a/src/shared/types/types-620.ts
+++ b/src/shared/types/types-620.ts
@@ -1,5 +1,3 @@
-import { BaseTableState } from "./types";
-
 enum Color {
 	LIGHT_GRAY = "light gray",
 	GRAY = "gray",
@@ -100,6 +98,7 @@ interface TableModel {
 	tags: Tag[];
 }
 
-export interface TableState620 extends BaseTableState {
+export interface TableState620 {
+	pluginVersion: string;
 	model: TableModel;
 }

--- a/src/shared/types/types-630.ts
+++ b/src/shared/types/types-630.ts
@@ -1,5 +1,3 @@
-import { BaseTableState } from "./types";
-
 enum Color {
 	LIGHT_GRAY = "light gray",
 	GRAY = "gray",
@@ -100,6 +98,7 @@ interface TableModel {
 	tags: Tag[];
 }
 
-export interface TableState630 extends BaseTableState {
+export interface TableState630 {
+	pluginVersion: string;
 	model: TableModel;
 }

--- a/src/shared/types/types-670.ts
+++ b/src/shared/types/types-670.ts
@@ -1,5 +1,3 @@
-import { BaseTableState } from "./types";
-
 enum Color {
 	LIGHT_GRAY = "light gray",
 	GRAY = "gray",
@@ -143,6 +141,7 @@ interface TableModel {
 	tags: Tag[];
 }
 
-export interface TableState670 extends BaseTableState {
+export interface TableState670 {
+	pluginVersion: string;
 	model: TableModel;
 }

--- a/src/shared/types/types-691.ts
+++ b/src/shared/types/types-691.ts
@@ -1,5 +1,3 @@
-import { BaseTableState } from "./types";
-
 enum Color {
 	LIGHT_GRAY = "light gray",
 	GRAY = "gray",
@@ -166,6 +164,7 @@ interface TableModel {
 	filterRules: FilterRule[];
 }
 
-export interface TableState691 extends BaseTableState {
+export interface TableState691 {
+	pluginVersion: string;
 	model: TableModel;
 }

--- a/src/shared/types/types.ts
+++ b/src/shared/types/types.ts
@@ -162,11 +162,7 @@ export interface TableModel {
 	footerCells: FooterCell[];
 	filterRules: FilterRule[];
 }
-
-export interface BaseTableState {
-	pluginVersion: number;
-}
-
-export interface TableState extends BaseTableState {
+export interface TableState {
+	pluginVersion: string;
 	model: TableModel;
 }

--- a/src/shared/versioning.spec.ts
+++ b/src/shared/versioning.spec.ts
@@ -1,0 +1,40 @@
+import { isVersionLessThan, legacyVersionToString } from "./versioning";
+
+describe("legacyVersionToString", () => {
+	it("should return a version string", () => {
+		const result = legacyVersionToString("152");
+		expect(result).toEqual("1.5.2");
+	});
+});
+
+describe("isVersionLessThan", () => {
+	it("should return true if oldVersion is a patch version less than newVersion", () => {
+		const result = isVersionLessThan("1.0.0", "1.0.1");
+		expect(result).toEqual(true);
+	});
+
+	it("should return true if oldVersion is a minor version less than newVersion", () => {
+		const result = isVersionLessThan("1.0.0", "1.1.0");
+		expect(result).toEqual(true);
+	});
+
+	it("should return true if oldVersion is a major version less than newVersion", () => {
+		const result = isVersionLessThan("1.0.0", "2.0.0");
+		expect(result).toEqual(true);
+	});
+
+	it("should return false if oldVersion is a patch version greater than newVersion", () => {
+		const result = isVersionLessThan("1.0.1", "1.0.0");
+		expect(result).toEqual(false);
+	});
+
+	it("should return false if a is a major version less than b", () => {
+		const result = isVersionLessThan("1.1.0", "1.0.0");
+		expect(result).toEqual(false);
+	});
+
+	it("should return false if a is a major version less than b", () => {
+		const result = isVersionLessThan("2.0.0", "1.0.0");
+		expect(result).toEqual(false);
+	});
+});

--- a/src/shared/versioning.ts
+++ b/src/shared/versioning.ts
@@ -1,0 +1,23 @@
+export const legacyVersionToString = (number: string) => {
+	return number.split("").join(".");
+};
+
+export const isVersionLessThan = (oldVersion: string, newVersion: string) => {
+	const oldVersionArray = oldVersion.split(".");
+	const newVersionArray = newVersion.split(".");
+
+	for (let i = 0; i < oldVersionArray.length; i++) {
+		const oldVersionNumber = parseInt(oldVersionArray[i]);
+		const newVersionNumber = parseInt(newVersionArray[i]);
+
+		if (oldVersionNumber < newVersionNumber) {
+			return true;
+		}
+
+		if (oldVersionNumber > newVersionNumber) {
+			return false;
+		}
+	}
+
+	return false;
+};


### PR DESCRIPTION
This update will change the type of `pluginVersion` from a number to string. The version string follows the semantic versioning pattern <major.minor.path> e.g. "6.10.0"