### PR TITLE
Ignore dangling tag cell ids

### DIFF
--- a/src/data/serialize-table-state.ts
+++ b/src/data/serialize-table-state.ts
@@ -279,10 +279,12 @@ export const deserializeTableState = (data: string): TableState => {
 				const cell: unknown | undefined = bodyCells.find(
 					(cell) => cell.id === cellId
 				);
-				if (!cell)
-					throw new CellNotFoundError({
-						id: cellId,
-					});
+
+				//If the cell doesn't exist, then don't migrate it
+				//It seems that in older table versions the cellIds array of tags wasn't being cleaned up
+				//properly when a column, row, or cell was deleted. Therefore there will still be some
+				//dangling cellIds in the tags array.
+				if (!cell) return;
 
 				const typedCell = cell as BodyCell;
 				typedCell.tagIds.push(id);


### PR DESCRIPTION
This update fixes #542. The issue is that the previous table versions didn't always remove cell id references when a cell was deleted. The solution is to ignore the dangling tag cell ids during migration because the cell no longer exists.