### PR TITLE
Fix number input

### DIFF
--- a/src/react/table-app/currency-cell-edit/index.tsx
+++ b/src/react/table-app/currency-cell-edit/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { useCompare, useInputSelection } from "src/shared/hooks";
-import { isValidNumberInput } from "src/shared/validators";
+import { isNumber, isValidNumberInput } from "src/shared/validators";
 import { MenuCloseRequest } from "src/shared/menu/types";
 import { numberInputStyle } from "src/react/table-app/shared-styles";
 
@@ -18,7 +18,8 @@ export default function CurrencyCellEdit({
 	onChange,
 	onMenuClose,
 }: Props) {
-	const [localValue, setLocalValue] = React.useState(value);
+	const initialValue = isNumber(value) ? value : "";
+	const [localValue, setLocalValue] = React.useState(initialValue);
 	const inputRef = React.useRef<HTMLInputElement | null>(null);
 	const { setPreviousSelectionStart } = useInputSelection(
 		inputRef,

--- a/src/react/table-app/number-cell-edit/index.tsx
+++ b/src/react/table-app/number-cell-edit/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { useCompare, useInputSelection } from "src/shared/hooks";
-import { isValidNumberInput } from "src/shared/validators";
+import { isNumber, isValidNumberInput } from "src/shared/validators";
 import { MenuCloseRequest } from "src/shared/menu/types";
 import { numberInputStyle } from "src/react/table-app/shared-styles";
 
@@ -18,7 +18,8 @@ export default function NumberCellEdit({
 	onChange,
 	onMenuClose,
 }: Props) {
-	const [localValue, setLocalValue] = React.useState(value);
+	const initialValue = isNumber(value) ? value : "";
+	const [localValue, setLocalValue] = React.useState(initialValue);
 	const inputRef = React.useRef<HTMLInputElement | null>(null);
 	const { setPreviousSelectionStart } = useInputSelection(
 		inputRef,

--- a/src/shared/export/cell-content.ts
+++ b/src/shared/export/cell-content.ts
@@ -46,12 +46,17 @@ export const getEmbedContent = (markdown: string) => {
 	return markdown;
 };
 
+export const getNumberCellContent = (value: string) => {
+	if (isNumber(value)) return value;
+	return "";
+};
+
 export const getCurrencyCellContent = (
 	value: string,
 	currencyType: CurrencyType
 ) => {
 	if (isNumber(value)) return stringToCurrencyString(value, currencyType);
-	return value;
+	return "";
 };
 
 export const getCellContent = (
@@ -62,8 +67,9 @@ export const getCellContent = (
 	switch (column.type) {
 		case CellType.TEXT:
 		case CellType.FILE:
-		case CellType.NUMBER:
 			return cell.markdown;
+		case CellType.NUMBER:
+			return getNumberCellContent(cell.markdown);
 		case CellType.EMBED:
 			return getEmbedContent(cell.markdown);
 		case CellType.CHECKBOX:


### PR DESCRIPTION
This update will handle non-number values when going from a cell type of `Text` to `Number`.

If the markdown is not a number, they we will render an empty string. Also, when we open the edit menu, we will render an empty string. This will allow the user to add a new number value. 