### PR TITLE
Render markdown option

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -5,3 +5,4 @@
 | Create new tables in attachment folder                    | `<true/false>`  |
 | Custom location for new tables                            | `<folder path>` |
 | Create table name based on active file name and timestamp | `<true/false>`  |
+| Render markdown values when exporting                     | `<true/false>`  |

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,11 @@ import { MarkdownView, Plugin, TAbstractFile, TFile, TFolder } from "obsidian";
 import NLTSettingsTab from "./obsidian/nlt-settings-tab";
 
 import { store } from "./redux/global/store";
-import { setDarkMode, setDebugMode } from "./redux/global/global-slice";
+import {
+	setDarkMode,
+	setDebugMode,
+	setExportRenderMarkdown,
+} from "./redux/global/global-slice";
 import { NLTView, NOTION_LIKE_TABLES_VIEW } from "./obsidian/nlt-view";
 import { TABLE_EXTENSION } from "./data/constants";
 import { createTableFile } from "src/data/table-file";
@@ -34,6 +38,7 @@ export interface NLTSettings {
 	createAtObsidianAttachmentFolder: boolean;
 	customFolderForNewTables: string;
 	nameWithActiveFileNameAndTimestamp: boolean;
+	exportRenderMarkdown: boolean;
 }
 
 export const DEFAULT_SETTINGS: NLTSettings = {
@@ -41,6 +46,7 @@ export const DEFAULT_SETTINGS: NLTSettings = {
 	createAtObsidianAttachmentFolder: false,
 	customFolderForNewTables: "",
 	nameWithActiveFileNameAndTimestamp: false,
+	exportRenderMarkdown: true,
 };
 export default class NLTPlugin extends Plugin {
 	settings: NLTSettings;
@@ -373,6 +379,9 @@ export default class NLTPlugin extends Plugin {
 			{},
 			DEFAULT_SETTINGS,
 			await this.loadData()
+		);
+		store.dispatch(
+			setExportRenderMarkdown(this.settings.exportRenderMarkdown)
 		);
 	}
 

--- a/src/obsidian-shim/build/export-events.ts
+++ b/src/obsidian-shim/build/export-events.ts
@@ -11,17 +11,19 @@ import { exportToMarkdown } from "src/shared/export/export-to-markdown";
 import { ExportType } from "src/shared/export/types";
 import { TableState } from "src/shared/types";
 import { useMountState } from "./mount-context";
+import { useAppSelector } from "src/redux/global/hooks";
 
 export const useExportEvents = (state: TableState) => {
 	const { filePath } = useMountState();
 	const { appId } = useMountState();
+	const { exportRenderMarkdown } = useAppSelector((state) => state.global);
 
 	React.useEffect(() => {
 		function handleDownloadCSV() {
 			if (isEventForThisApp(appId)) {
 				//Set timeout to wait for the command window to disappear
 				setTimeout(() => {
-					const data = exportToCSV(state);
+					const data = exportToCSV(state, exportRenderMarkdown);
 					const exportFileName = getExportFileName(filePath);
 					const blobType = getBlobTypeForExportType(
 						ExportType.MARKDOWN
@@ -35,7 +37,7 @@ export const useExportEvents = (state: TableState) => {
 			if (isEventForThisApp(appId)) {
 				//Set timeout to wait for the command window to disappear
 				setTimeout(() => {
-					const data = exportToMarkdown(state);
+					const data = exportToMarkdown(state, exportRenderMarkdown);
 					const exportFileName = getExportFileName(filePath);
 					const blobType = getBlobTypeForExportType(
 						ExportType.MARKDOWN
@@ -54,5 +56,5 @@ export const useExportEvents = (state: TableState) => {
 			app.workspace.off(EVENT_DOWNLOAD_CSV, handleDownloadCSV);
 			app.workspace.off(EVENT_DOWNLOAD_MARKDOWN, handleDownloadMarkdown);
 		};
-	}, [filePath, state, appId]);
+	}, [filePath, state, appId, exportRenderMarkdown]);
 };

--- a/src/obsidian/nlt-export-modal.tsx
+++ b/src/obsidian/nlt-export-modal.tsx
@@ -3,6 +3,8 @@ import { NLTView } from "./nlt-view";
 import { Root, createRoot } from "react-dom/client";
 import { deserializeTableState } from "src/data/serialize-table-state";
 import { ExportApp } from "src/react/export-app";
+import { Provider } from "react-redux";
+import { store } from "src/redux/global/store";
 
 export default class NLTExportModal extends Modal {
 	root: Root;
@@ -25,7 +27,9 @@ export default class NLTExportModal extends Modal {
 
 			this.root = createRoot(container);
 			this.root.render(
-				<ExportApp tableState={state} filePath={this.filePath} />
+				<Provider store={store}>
+					<ExportApp tableState={state} filePath={this.filePath} />
+				</Provider>
 			);
 		}
 	}

--- a/src/obsidian/nlt-settings-tab.ts
+++ b/src/obsidian/nlt-settings-tab.ts
@@ -82,10 +82,31 @@ export default class NLTSettingsTab extends PluginSettingTab {
 				});
 			});
 
+		const exportRenderMarkdownDesc = new DocumentFragment();
+		exportRenderMarkdownDesc.createSpan({}, (span) => {
+			span.innerHTML =
+				"This will cause all exported values to be rendered in markdown format. Disable this option if you primarily export in CSV and don't want markdown, like links wrapped in brackets.";
+		});
+
+		new Setting(containerEl).setName("Export").setHeading();
+		new Setting(containerEl)
+			.setName("Render markdown values")
+			.setDesc(exportRenderMarkdownDesc)
+			.addToggle((cb) => {
+				cb.setValue(this.plugin.settings.exportRenderMarkdown).onChange(
+					async (value) => {
+						this.plugin.settings.exportRenderMarkdown = value;
+						await this.plugin.saveSettings();
+					}
+				);
+			});
+
 		new Setting(containerEl).setName("Debug").setHeading();
 		new Setting(containerEl)
 			.setName("Debug mode")
-			.setDesc("Turns on console.log for various table events")
+			.setDesc(
+				"Turns on console.log for plugin events. This is useful for troubleshooting."
+			)
 			.addToggle((cb) => {
 				cb.setValue(this.plugin.settings.shouldDebug).onChange(
 					async (value) => {

--- a/src/react/export-app/index.tsx
+++ b/src/react/export-app/index.tsx
@@ -24,6 +24,7 @@ export function ExportApp({ tableState, filePath }: Props) {
 	const [exportType, setExportType] = React.useState<ExportType>(
 		ExportType.UNSELECTED
 	);
+	const [renderMarkdown, setRenderMarkdown] = React.useState<boolean>(false);
 
 	async function handleCopyClick(value: string) {
 		await navigator.clipboard.writeText(value);
@@ -38,9 +39,9 @@ export function ExportApp({ tableState, filePath }: Props) {
 
 	let content = "";
 	if (exportType === ExportType.MARKDOWN) {
-		content = exportToMarkdown(tableState);
+		content = exportToMarkdown(tableState, renderMarkdown);
 	} else if (exportType === ExportType.CSV) {
-		content = exportToCSV(tableState);
+		content = exportToCSV(tableState, renderMarkdown);
 	}
 
 	return (
@@ -67,6 +68,20 @@ export function ExportApp({ tableState, filePath }: Props) {
 					{exportType !== ExportType.UNSELECTED && (
 						<>
 							<ContentTextArea value={content} />
+							<Stack isVertical spacing="sm">
+								<label htmlFor="render-markdown">
+									Render markdown
+								</label>
+								<input
+									id="render-markdown"
+									type="checkbox"
+									checked={renderMarkdown}
+									onChange={() =>
+										setRenderMarkdown(!renderMarkdown)
+									}
+								/>
+							</Stack>
+
 							<Stack>
 								<button
 									className="mod-cta"

--- a/src/react/export-app/index.tsx
+++ b/src/react/export-app/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../shared/export/download-utils";
 import { exportToCSV } from "src/shared/export/export-to-csv";
 import { css } from "@emotion/react";
+import { useAppSelector } from "src/redux/global/hooks";
 
 interface Props {
 	tableState: TableState;
@@ -24,7 +25,9 @@ export function ExportApp({ tableState, filePath }: Props) {
 	const [exportType, setExportType] = React.useState<ExportType>(
 		ExportType.UNSELECTED
 	);
-	const [renderMarkdown, setRenderMarkdown] = React.useState<boolean>(false);
+	const { exportRenderMarkdown } = useAppSelector((state) => state.global);
+	const [renderMarkdown, setRenderMarkdown] =
+		React.useState<boolean>(exportRenderMarkdown);
 
 	async function handleCopyClick(value: string) {
 		await navigator.clipboard.writeText(value);

--- a/src/react/table-app/embed-cell/index.tsx
+++ b/src/react/table-app/embed-cell/index.tsx
@@ -3,7 +3,6 @@ import { getEmbedCellContent } from "src/shared/cell-content/embed-cell-content"
 import { useRenderMarkdown } from "src/obsidian-shim/development/render-utils";
 import { getSpacing } from "src/shared/spacing";
 import { AspectRatio, PaddingSize } from "src/shared/types";
-import { isURL } from "src/shared/validators";
 import Text from "src/react/shared/text";
 import { appendOrReplaceFirstChild } from "src/shared/render/utils";
 
@@ -60,13 +59,10 @@ export default function EmbedCell({
 	horizontalPadding,
 	verticalPadding,
 }: Props) {
-	let linkMarkdown = "";
-	let isValidURL = false;
+	let isValidURL = true;
 
-	if (isURL(markdown)) {
-		isValidURL = true;
-		linkMarkdown = getEmbedCellContent(markdown);
-	}
+	const content = getEmbedCellContent(markdown, true);
+	if (content === "") isValidURL = false;
 	return (
 		<div
 			className="NLT__embed-cell"
@@ -77,7 +73,7 @@ export default function EmbedCell({
 		>
 			{isValidURL && (
 				<EmbeddedLink
-					markdown={linkMarkdown}
+					markdown={content}
 					aspectRatio={aspectRatio}
 					horizontalPadding={horizontalPadding}
 					verticalPadding={verticalPadding}

--- a/src/redux/global/global-slice.ts
+++ b/src/redux/global/global-slice.ts
@@ -3,11 +3,13 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 interface GlobalState {
 	isDarkMode: boolean;
 	shouldDebug: boolean;
+	exportRenderMarkdown: boolean;
 }
 
 const initialState: GlobalState = {
 	isDarkMode: false,
 	shouldDebug: false,
+	exportRenderMarkdown: true,
 };
 
 //This is the global slice of the redux store.
@@ -22,8 +24,12 @@ const globalSlice = createSlice({
 		setDebugMode(state, action: PayloadAction<boolean>) {
 			state.shouldDebug = action.payload;
 		},
+		setExportRenderMarkdown(state, action: PayloadAction<boolean>) {
+			state.exportRenderMarkdown = action.payload;
+		},
 	},
 });
 
-export const { setDarkMode, setDebugMode } = globalSlice.actions;
+export const { setDarkMode, setDebugMode, setExportRenderMarkdown } =
+	globalSlice.actions;
 export default globalSlice.reducer;

--- a/src/shared/cell-content/checkbox-cell-content.spec.ts
+++ b/src/shared/cell-content/checkbox-cell-content.spec.ts
@@ -1,0 +1,23 @@
+import { getCheckboxCellContent } from "./checkbox-cell-content";
+
+describe("getCheckboxCellContent", () => {
+	it("should return true if markdown is checked", () => {
+		const result = getCheckboxCellContent("[x]", false);
+		expect(result).toEqual("true");
+	});
+
+	it("should return false if markdown not checked", () => {
+		const result = getCheckboxCellContent("[ ]", false);
+		expect(result).toEqual("false");
+	});
+
+	it("should return the unchecked markdown if renderMarkdown is true", () => {
+		const result = getCheckboxCellContent("[ ]", true);
+		expect(result).toEqual("[ ]");
+	});
+
+	it("should return the checked markdown if renderMarkdown is true", () => {
+		const result = getCheckboxCellContent("[x]", true);
+		expect(result).toEqual("[x]");
+	});
+});

--- a/src/shared/cell-content/checkbox-cell-content.ts
+++ b/src/shared/cell-content/checkbox-cell-content.ts
@@ -1,6 +1,11 @@
 import { isCheckboxChecked } from "../validators";
 
-export const getCheckboxCellContent = (markdown: string) => {
+export const getCheckboxCellContent = (
+	markdown: string,
+	renderMarkdown: boolean
+) => {
+	if (renderMarkdown) return markdown;
+
 	if (isCheckboxChecked(markdown)) return "true";
 	return "false";
 };

--- a/src/shared/cell-content/currency-cell-content.spec.ts
+++ b/src/shared/cell-content/currency-cell-content.spec.ts
@@ -1,0 +1,20 @@
+import { CurrencyType } from "../types";
+import { getCurrencyCellContent } from "./currency-cell-content";
+
+describe("getCurrencyCellContent", () => {
+	it("should return the currency string if value is a number", () => {
+		const result = getCurrencyCellContent(
+			"123",
+			CurrencyType.UNITED_STATES
+		);
+		expect(result).toEqual("$123.00");
+	});
+
+	it("should return an empty string if value is not a number", () => {
+		const result = getCurrencyCellContent(
+			"abc123",
+			CurrencyType.UNITED_STATES
+		);
+		expect(result).toEqual("");
+	});
+});

--- a/src/shared/cell-content/date-cell-content.spec.ts
+++ b/src/shared/cell-content/date-cell-content.spec.ts
@@ -1,0 +1,14 @@
+import { DateFormat } from "../types";
+import { getDateCellContent } from "./date-cell-content";
+
+describe("getDateCellContent", () => {
+	it("should return a date string if the time is a number", () => {
+		const result = getDateCellContent(1704006000000, DateFormat.MM_DD_YYYY);
+		expect(result).toEqual("12/31/2023");
+	});
+
+	it("should return an empty string if time is null", () => {
+		const result = getDateCellContent(null, DateFormat.DD_MM_YYYY);
+		expect(result).toEqual("");
+	});
+});

--- a/src/shared/cell-content/embed-cell-content.spec.ts
+++ b/src/shared/cell-content/embed-cell-content.spec.ts
@@ -1,0 +1,18 @@
+import { getEmbedCellContent } from "./embed-cell-content";
+
+describe("getEmbedCellContent", () => {
+	it("should return embedded link markdown if renderMarkdown is true", () => {
+		const result = getEmbedCellContent("https://youtube.com", true);
+		expect(result).toEqual("![](https://youtube.com)");
+	});
+
+	it("should return the plain text if renderMarkdown is false", () => {
+		const result = getEmbedCellContent("https://youtube.com", false);
+		expect(result).toEqual("https://youtube.com");
+	});
+
+	it("should return an empty string if not a valid url", () => {
+		const result = getEmbedCellContent("url", true);
+		expect(result).toEqual("");
+	});
+});

--- a/src/shared/cell-content/embed-cell-content.ts
+++ b/src/shared/cell-content/embed-cell-content.ts
@@ -1,6 +1,12 @@
 import { isURL } from "../validators";
 
-export const getEmbedCellContent = (markdown: string) => {
-	if (isURL(markdown)) return `![](${markdown})`;
-	return markdown;
+export const getEmbedCellContent = (
+	markdown: string,
+	renderMarkdown: boolean
+) => {
+	if (isURL(markdown)) {
+		if (renderMarkdown) return `![](${markdown})`;
+		return markdown;
+	}
+	return "";
 };

--- a/src/shared/cell-content/index.ts
+++ b/src/shared/cell-content/index.ts
@@ -4,6 +4,7 @@ import { getCurrencyCellContent } from "./currency-cell-content";
 import { getDateCellContent } from "./date-cell-content";
 import { getEmbedCellContent } from "./embed-cell-content";
 import { getNumberCellContent } from "./number-cell-content";
+import { getTextCellContent } from "./text-cell-content";
 import { getTimeCellContent } from "./time-content";
 
 const getTagCellContent = (column: Column, cell: BodyCell) => {
@@ -16,18 +17,19 @@ const getTagCellContent = (column: Column, cell: BodyCell) => {
 export const getCellContent = (
 	column: Column,
 	row: BodyRow,
-	cell: BodyCell
+	cell: BodyCell,
+	renderMarkdown: boolean
 ) => {
 	switch (column.type) {
 		case CellType.TEXT:
 		case CellType.FILE:
-			return cell.markdown;
+			return getTextCellContent(cell.markdown, renderMarkdown);
 		case CellType.NUMBER:
 			return getNumberCellContent(cell.markdown);
 		case CellType.EMBED:
-			return getEmbedCellContent(cell.markdown);
+			return getEmbedCellContent(cell.markdown, renderMarkdown);
 		case CellType.CHECKBOX:
-			return getCheckboxCellContent(cell.markdown);
+			return getCheckboxCellContent(cell.markdown, renderMarkdown);
 		case CellType.CURRENCY:
 			return getCurrencyCellContent(cell.markdown, column.currencyType);
 		case CellType.TAG:

--- a/src/shared/cell-content/number-cell-content.spec.ts
+++ b/src/shared/cell-content/number-cell-content.spec.ts
@@ -1,0 +1,13 @@
+import { getNumberCellContent } from "./number-cell-content";
+
+describe("getNumberCellContent", () => {
+	it("should return the number if value is a number", () => {
+		const result = getNumberCellContent("123");
+		expect(result).toEqual("123");
+	});
+
+	it("should return an empty string if value is not a number", () => {
+		const result = getNumberCellContent("abc123");
+		expect(result).toEqual("");
+	});
+});

--- a/src/shared/cell-content/text-cell-content.spec.ts
+++ b/src/shared/cell-content/text-cell-content.spec.ts
@@ -1,0 +1,13 @@
+import { getTextCellContent } from "./text-cell-content";
+
+describe("getTextCellContent", () => {
+	it("should return markdown if renderMarkdown is true", () => {
+		const result = getTextCellContent("[[inbox/filename|filename]]", true);
+		expect(result).toEqual("[[inbox/filename|filename]]");
+	});
+
+	it("should return the text if renderMarkdown is false", () => {
+		const result = getTextCellContent("[[inbox/filename|filename]]", false);
+		expect(result).toEqual("inbox/filename");
+	});
+});

--- a/src/shared/cell-content/text-cell-content.ts
+++ b/src/shared/cell-content/text-cell-content.ts
@@ -1,0 +1,12 @@
+import { WIKI_LINK_REGEX } from "src/data/constants";
+
+export const getTextCellContent = (
+	markdown: string,
+	renderMarkdown: boolean
+) => {
+	if (!renderMarkdown)
+		return markdown.replace(WIKI_LINK_REGEX, (_match, path) => {
+			return path;
+		});
+	return markdown;
+};

--- a/src/shared/cell-content/time-content.spec.ts
+++ b/src/shared/cell-content/time-content.spec.ts
@@ -1,0 +1,14 @@
+import { DateFormat } from "../types";
+import { getTimeCellContent } from "./time-content";
+
+describe("getTimeCellContent", () => {
+	it("should return a datetime string if the time is a number", () => {
+		const result = getTimeCellContent(1704006000000, DateFormat.MM_DD_YYYY);
+		expect(result).toEqual("12/31/2023 12:00 AM");
+	});
+
+	it("should return an empty string if time is null", () => {
+		const result = getTimeCellContent(null, DateFormat.DD_MM_YYYY);
+		expect(result).toEqual("");
+	});
+});

--- a/src/shared/export/export-to-csv.tsx
+++ b/src/shared/export/export-to-csv.tsx
@@ -3,7 +3,10 @@ import Papa from "papaparse";
 import { tableStateToArray } from "./table-state-to-array";
 import { TableState } from "../types";
 
-export const exportToCSV = (tableState: TableState): string => {
-	const arr = tableStateToArray(tableState);
+export const exportToCSV = (
+	tableState: TableState,
+	renderMarkdown: boolean
+): string => {
+	const arr = tableStateToArray(tableState, renderMarkdown);
 	return Papa.unparse(arr);
 };

--- a/src/shared/export/export-to-markdown.tsx
+++ b/src/shared/export/export-to-markdown.tsx
@@ -2,7 +2,10 @@ import { TableState } from "../types";
 import { markdownTable } from "markdown-table";
 import { tableStateToArray } from "./table-state-to-array";
 
-export const exportToMarkdown = (tableState: TableState): string => {
-	const arr = tableStateToArray(tableState);
+export const exportToMarkdown = (
+	tableState: TableState,
+	renderMarkdown: boolean
+): string => {
+	const arr = tableStateToArray(tableState, renderMarkdown);
 	return markdownTable(arr);
 };

--- a/src/shared/export/table-state-to-array.tsx
+++ b/src/shared/export/table-state-to-array.tsx
@@ -9,7 +9,8 @@ const serializeHeaderCells = (cells: HeaderCell[]): string[] => {
 const serializeBodyCells = (
 	columns: Column[],
 	rows: BodyRow[],
-	cells: BodyCell[]
+	cells: BodyCell[],
+	renderMarkdown: boolean
 ): string[][] => {
 	return rows.map((row) => {
 		const rowCells = cells.filter((cell) => cell.rowId === row.id);
@@ -18,18 +19,22 @@ const serializeBodyCells = (
 				(column) => column.id === cell.columnId
 			);
 			if (!column) throw new ColumNotFoundError(cell.columnId);
-			return getCellContent(column, row, cell);
+			return getCellContent(column, row, cell, renderMarkdown);
 		});
 	});
 };
 
-export const tableStateToArray = (tableState: TableState): string[][] => {
+export const tableStateToArray = (
+	tableState: TableState,
+	renderMarkdown: boolean
+): string[][] => {
 	const { headerCells, bodyCells, bodyRows, columns } = tableState.model;
 	const serializedHeaderCells = serializeHeaderCells(headerCells);
 	const serializedBodyCells = serializeBodyCells(
 		columns,
 		bodyRows,
-		bodyCells
+		bodyCells,
+		renderMarkdown
 	);
 	return [serializedHeaderCells, ...serializedBodyCells];
 };

--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -34,6 +34,7 @@ export const useInputSelection = (
 		}
 
 		setSelection();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [inputRef]);
 };
 


### PR DESCRIPTION
This update adds tests for all cell content functions. It also adds a `renderMarkdown` option for all cell content. This is relevant for people that render CSV files and want to export without markdown.