### PR TITLE
Add settings

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,8 +1,9 @@
 ## Settings
 
-| Name                                                      | Value           |
-| --------------------------------------------------------- | --------------- |
-| Create new tables in attachment folder                    | `<true/false>`  |
-| Custom location for new tables                            | `<folder path>` |
-| Create table name based on active file name and timestamp | `<true/false>`  |
-| Render markdown values when exporting                     | `<true/false>`  |
+| Name                                   | Value           |
+| -------------------------------------- | --------------- |
+| Create new tables in attachment folder | `<true/false>`  |
+| Custom location for new tables         | `<folder path>` |
+| Export content as markdown             | `<true/false>`  |
+| Default embedded table width           | `<width>`       |
+| Default embedded table height          | `<height>`      |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,9 +1,9 @@
 ## Settings
 
-| Name                                   | Value           |
-| -------------------------------------- | --------------- |
-| Create new tables in attachment folder | `<true/false>`  |
-| Custom location for new tables         | `<folder path>` |
-| Export content as markdown             | `<true/false>`  |
-| Default embedded table width           | `<width>`       |
-| Default embedded table height          | `<height>`      |
+| Name                                   | Value          |
+| -------------------------------------- | -------------- |
+| Create new tables in attachment folder | `<true/false>` |
+| Default location for new tables        | `<path>`       |
+| Export content as markdown             | `<true/false>` |
+| Default embedded table width           | `<width>`      |
+| Default embedded table height          | `<height>`     |

--- a/src/data/table-file.ts
+++ b/src/data/table-file.ts
@@ -1,27 +1,11 @@
-import { Notice, MarkdownView } from "obsidian";
-import { moment } from "obsidian";
+import { Notice } from "obsidian";
 import { createFile, createFolder } from "./file-operations";
 import { createTableState } from "./table-state-factory";
 import { serializeTableState } from "./serialize-table-state";
 import { DEFAULT_TABLE_NAME, TABLE_EXTENSION } from "./constants";
 
-const getActiveFileNameAndTimestamp = () => {
-	const activeView = app.workspace.getActiveViewOfType(MarkdownView);
-	if (!activeView) return null;
-
-	const file = activeView.file;
-	if (!file) return null;
-
-	return `${file.basename}-${moment().format().replaceAll(":", ".")}`;
-};
-
-const getFileName = (useActiveFileNameAndTimestamp: boolean): string => {
-	let fileName = DEFAULT_TABLE_NAME;
-
-	if (useActiveFileNameAndTimestamp) {
-		const name = getActiveFileNameAndTimestamp();
-		if (name) fileName = name;
-	}
+const getFileName = (): string => {
+	const fileName = DEFAULT_TABLE_NAME;
 
 	return `${fileName}.${TABLE_EXTENSION}`;
 };
@@ -31,10 +15,7 @@ export const getFilePath = (folderPath: string, fileName: string) => {
 	return folderPath + "/" + fileName;
 };
 
-export const createTableFile = async (options: {
-	folderPath: string;
-	useActiveFileNameAndTimestamp: boolean;
-}) => {
+export const createTableFile = async (options: { folderPath: string }) => {
 	try {
 		//Create folder if it doesn't exist
 		if (options.folderPath !== "") {
@@ -42,7 +23,7 @@ export const createTableFile = async (options: {
 				await createFolder(options.folderPath);
 		}
 
-		const fileName = getFileName(options.useActiveFileNameAndTimestamp);
+		const fileName = getFileName();
 		const tableState = createTableState(1, 1);
 		const serialized = serializeTableState(tableState);
 		const filePath = getFilePath(options.folderPath, fileName);

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,6 @@ export interface NLTSettings {
 	shouldDebug: boolean;
 	createAtObsidianAttachmentFolder: boolean;
 	customFolderForNewTables: string;
-	nameWithActiveFileNameAndTimestamp: boolean;
 	exportRenderMarkdown: boolean;
 	defaultEmbedWidth: string;
 	defaultEmbedHeight: string;
@@ -43,7 +42,6 @@ export const DEFAULT_SETTINGS: NLTSettings = {
 	shouldDebug: false,
 	createAtObsidianAttachmentFolder: false,
 	customFolderForNewTables: "",
-	nameWithActiveFileNameAndTimestamp: false,
 	exportRenderMarkdown: true,
 	defaultEmbedWidth: "100%",
 	defaultEmbedHeight: "340px",
@@ -111,8 +109,6 @@ export default class NLTPlugin extends Plugin {
 
 		const filePath = await createTableFile({
 			folderPath,
-			useActiveFileNameAndTimestamp:
-				this.settings.nameWithActiveFileNameAndTimestamp,
 		});
 		if (embedded) return filePath;
 		//Open file in a new tab and set it to active

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,7 @@ import { MarkdownView, Plugin, TAbstractFile, TFile, TFolder } from "obsidian";
 import NLTSettingsTab from "./obsidian/nlt-settings-tab";
 
 import { store } from "./redux/global/store";
-import {
-	setDarkMode,
-	setDebugMode,
-	setExportRenderMarkdown,
-} from "./redux/global/global-slice";
+import { setDarkMode, setSettings } from "./redux/global/global-slice";
 import { NLTView, NOTION_LIKE_TABLES_VIEW } from "./obsidian/nlt-view";
 import { TABLE_EXTENSION } from "./data/constants";
 import { createTableFile } from "src/data/table-file";
@@ -39,6 +35,8 @@ export interface NLTSettings {
 	customFolderForNewTables: string;
 	nameWithActiveFileNameAndTimestamp: boolean;
 	exportRenderMarkdown: boolean;
+	defaultEmbedWidth: string;
+	defaultEmbedHeight: string;
 }
 
 export const DEFAULT_SETTINGS: NLTSettings = {
@@ -47,7 +45,10 @@ export const DEFAULT_SETTINGS: NLTSettings = {
 	customFolderForNewTables: "",
 	nameWithActiveFileNameAndTimestamp: false,
 	exportRenderMarkdown: true,
+	defaultEmbedWidth: "100%",
+	defaultEmbedHeight: "340px",
 };
+
 export default class NLTPlugin extends Plugin {
 	settings: NLTSettings;
 
@@ -229,7 +230,6 @@ export default class NLTPlugin extends Plugin {
 		this.app.workspace.onLayoutReady(() => {
 			const isDark = hasDarkTheme();
 			store.dispatch(setDarkMode(isDark));
-			store.dispatch(setDebugMode(this.settings.shouldDebug));
 		});
 	}
 
@@ -380,13 +380,12 @@ export default class NLTPlugin extends Plugin {
 			DEFAULT_SETTINGS,
 			await this.loadData()
 		);
-		store.dispatch(
-			setExportRenderMarkdown(this.settings.exportRenderMarkdown)
-		);
+		store.dispatch(setSettings(this.settings));
 	}
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+		store.dispatch(setSettings(this.settings));
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -380,12 +380,12 @@ export default class NLTPlugin extends Plugin {
 			DEFAULT_SETTINGS,
 			await this.loadData()
 		);
-		store.dispatch(setSettings(this.settings));
+		store.dispatch(setSettings({ ...this.settings }));
 	}
 
 	async saveSettings() {
 		await this.saveData(this.settings);
-		store.dispatch(setSettings(this.settings));
+		store.dispatch(setSettings({ ...this.settings }));
 	}
 
 	/**

--- a/src/obsidian-shim/build/export-events.ts
+++ b/src/obsidian-shim/build/export-events.ts
@@ -16,7 +16,9 @@ import { useAppSelector } from "src/redux/global/hooks";
 export const useExportEvents = (state: TableState) => {
 	const { filePath } = useMountState();
 	const { appId } = useMountState();
-	const { exportRenderMarkdown } = useAppSelector((state) => state.global);
+	const { exportRenderMarkdown } = useAppSelector(
+		(state) => state.global.settings
+	);
 
 	React.useEffect(() => {
 		function handleDownloadCSV() {

--- a/src/obsidian-shim/development/main.tsx
+++ b/src/obsidian-shim/development/main.tsx
@@ -5,14 +5,20 @@ import { store } from "../../redux/global/store";
 import { v4 as uuidv4 } from "uuid";
 import { createTableState } from "../../data/table-state-factory";
 
-import { setDarkMode, setDebugMode } from "src/redux/global/global-slice";
+import { setDarkMode, setSettings } from "src/redux/global/global-slice";
 import "./app.css";
+import { DEFAULT_SETTINGS } from "src/main";
 
 const appId = uuidv4();
 const tableState = createTableState(2, 2);
 
 store.dispatch(setDarkMode(true));
-store.dispatch(setDebugMode(true));
+store.dispatch(
+	setSettings({
+		...DEFAULT_SETTINGS,
+		shouldDebug: true,
+	})
+);
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 	//<React.StrictMode>

--- a/src/obsidian/nlt-embedded-plugin.tsx
+++ b/src/obsidian/nlt-embedded-plugin.tsx
@@ -48,8 +48,10 @@ class NLTEmbeddedPlugin implements PluginValue {
 			const file = findEmbeddedTableFile(linkEl);
 			if (!file) return;
 
-			const width = getEmbeddedTableWidth(linkEl);
-			const height = getEmbeddedTableHeight(linkEl);
+			const { defaultEmbedWidth, defaultEmbedHeight } =
+				store.getState().global.settings;
+			const width = getEmbeddedTableWidth(linkEl, defaultEmbedWidth);
+			const height = getEmbeddedTableHeight(linkEl, defaultEmbedHeight);
 
 			linkEl.style.width = width;
 			linkEl.style.height = height;

--- a/src/obsidian/nlt-settings-tab.ts
+++ b/src/obsidian/nlt-settings-tab.ts
@@ -36,7 +36,7 @@ export default class NLTSettingsTab extends PluginSettingTab {
 		//Custom location
 		const customLocationDesc = new DocumentFragment();
 		customLocationDesc.createSpan({}, (span) => {
-			span.innerHTML = `Folder that new tables will be created in. Please don't include a slash at the start or end.<br>e.g. <strong>myfolder/subdirectory</strong><br><br>Default location is the vault root folder, if not specified.`;
+			span.innerHTML = `The folder that new tables will be created in. Please don't include a slash at the beginning or end of the value.<br>e.g. <strong>myfolder/subdirectory</strong><br><br>Default location is the vault root folder, if not specified.`;
 		});
 
 		if (this.plugin.settings.createAtObsidianAttachmentFolder === false) {
@@ -79,7 +79,7 @@ export default class NLTSettingsTab extends PluginSettingTab {
 		const exportRenderMarkdownDesc = new DocumentFragment();
 		exportRenderMarkdownDesc.createSpan({}, (span) => {
 			span.innerHTML =
-				"When enabled, content will be rendered as markdown. For example, a checkbox cell's content will be exported as `[ ]` or `[x]`. If you disable this option, the content will be exported as `true` or `false`.";
+				"If enabled, content will be exported as markdown. For example, if enabled, a checkbox cell's content will be exported as <strong>[ ]</strong> or <strong>[x]<strong>. If disabled, the content will be exported as <strong>true<strong> or <strong>false<strong>.";
 		});
 
 		new Setting(containerEl).setName("Export").setHeading();
@@ -102,7 +102,7 @@ export default class NLTSettingsTab extends PluginSettingTab {
 		const defaultEmbedWidthDesc = new DocumentFragment();
 		defaultEmbedWidthDesc.createSpan({}, (span) => {
 			span.innerHTML =
-				"The default embedded table width. Accepts valid HTML width values. Like `100px`, `50%`, etc.";
+				"The default embedded table width. Accepts valid HTML width values. Like <strong>100px<strong>, <strong>50%</strong>, etc.";
 		});
 
 		new Setting(containerEl)
@@ -120,7 +120,7 @@ export default class NLTSettingsTab extends PluginSettingTab {
 		const defaultEmbedHeightDesc = new DocumentFragment();
 		defaultEmbedHeightDesc.createSpan({}, (span) => {
 			span.innerHTML =
-				"The default embedded table height. Accepts valid HTML width values. Like `100px`, `50%`, etc.";
+				"The default embedded table height. Accepts valid HTML width values. Like <strong>100px</strong>, <strong>50%</strong>, etc.";
 		});
 
 		new Setting(containerEl)

--- a/src/obsidian/nlt-settings-tab.ts
+++ b/src/obsidian/nlt-settings-tab.ts
@@ -10,20 +10,10 @@ export default class NLTSettingsTab extends PluginSettingTab {
 		this.plugin = plugin;
 	}
 
-	display(): void {
-		const { containerEl } = this;
-
-		containerEl.empty();
-
-		containerEl.createEl("h2", { text: "Notion-Like Tables" });
-		containerEl.createSpan(
-			{},
-			(span) =>
-				(span.innerHTML = `<strong style="color: var(--text-accent); font-size: 12px;">Please restart Obsidian for these settings to take effect</strong>`)
-		);
-
+	private renderFileSettings(containerEl: HTMLElement) {
 		new Setting(containerEl).setName("File").setHeading();
 
+		//Attachments folder
 		const attachmentsFolderDesc = new DocumentFragment();
 		attachmentsFolderDesc.createSpan({}, (span) => {
 			span.innerHTML = `Create tables in the attachments folder defined in the Obsidian settings.<br><br>This can be changed in <span style="color: var(--text-accent);">Files & Links -> Default location for new attachments</span><br><br>Otherwise, the custom location below will be used.`;
@@ -43,6 +33,7 @@ export default class NLTSettingsTab extends PluginSettingTab {
 				});
 			});
 
+		//Custom location
 		const customLocationDesc = new DocumentFragment();
 		customLocationDesc.createSpan({}, (span) => {
 			span.innerHTML = `Folder that new tables will be created in. Please don't include a slash at the start or end.<br>e.g. <strong>myfolder/subdirectory</strong><br><br>Default location is the vault root folder, if not specified.`;
@@ -62,6 +53,7 @@ export default class NLTSettingsTab extends PluginSettingTab {
 				});
 		}
 
+		//Active file name
 		const activeFileNameTimestampDesc = new DocumentFragment();
 		activeFileNameTimestampDesc.createSpan({}, (span) => {
 			span.innerHTML = `If a markdown file is open, the active file name and current timestamp will be used as the table name.<br>e.g. if <strong>Test.md</strong> is open, the table will be named <strong>Test-2023-04-14T13.12.59-06.00.table</strong><br><br>Otherwise, the default table file name will be used.<br>e.g <strong>Untitled.table</strong>`;
@@ -81,16 +73,18 @@ export default class NLTSettingsTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				});
 			});
+	}
 
+	private renderExportSettings(containerEl: HTMLElement) {
 		const exportRenderMarkdownDesc = new DocumentFragment();
 		exportRenderMarkdownDesc.createSpan({}, (span) => {
 			span.innerHTML =
-				"This will cause all exported values to be rendered in markdown format. Disable this option if you primarily export in CSV and don't want markdown, like links wrapped in brackets.";
+				"When enabled, content will be rendered as markdown. For example, a checkbox cell's content will be exported as `[ ]` or `[x]`. If you disable this option, the content will be exported as `true` or `false`.";
 		});
 
 		new Setting(containerEl).setName("Export").setHeading();
 		new Setting(containerEl)
-			.setName("Render markdown values")
+			.setName("Export content as markdown")
 			.setDesc(exportRenderMarkdownDesc)
 			.addToggle((cb) => {
 				cb.setValue(this.plugin.settings.exportRenderMarkdown).onChange(
@@ -100,7 +94,49 @@ export default class NLTSettingsTab extends PluginSettingTab {
 					}
 				);
 			});
+	}
 
+	private renderEmbeddedTableSettings(containerEl: HTMLElement) {
+		new Setting(containerEl).setName("Embedded Tables").setHeading();
+
+		const defaultEmbedWidthDesc = new DocumentFragment();
+		defaultEmbedWidthDesc.createSpan({}, (span) => {
+			span.innerHTML =
+				"The default embedded table width. Accepts valid HTML width values. Like `100px`, `50%`, etc.";
+		});
+
+		new Setting(containerEl)
+			.setName("Default embedded table width")
+			.setDesc(defaultEmbedWidthDesc)
+			.addText((cb) => {
+				cb.setValue(this.plugin.settings.defaultEmbedWidth).onChange(
+					async (value) => {
+						this.plugin.settings.defaultEmbedWidth = value;
+						await this.plugin.saveSettings();
+					}
+				);
+			});
+
+		const defaultEmbedHeightDesc = new DocumentFragment();
+		defaultEmbedHeightDesc.createSpan({}, (span) => {
+			span.innerHTML =
+				"The default embedded table height. Accepts valid HTML width values. Like `100px`, `50%`, etc.";
+		});
+
+		new Setting(containerEl)
+			.setName("Default embedded table height")
+			.setDesc(defaultEmbedHeightDesc)
+			.addText((cb) => {
+				cb.setValue(this.plugin.settings.defaultEmbedHeight).onChange(
+					async (value) => {
+						this.plugin.settings.defaultEmbedHeight = value;
+						await this.plugin.saveSettings();
+					}
+				);
+			});
+	}
+
+	private renderDebugSettings(containerEl: HTMLElement) {
 		new Setting(containerEl).setName("Debug").setHeading();
 		new Setting(containerEl)
 			.setName("Debug mode")
@@ -115,5 +151,23 @@ export default class NLTSettingsTab extends PluginSettingTab {
 					}
 				);
 			});
+	}
+
+	display(): void {
+		const { containerEl } = this;
+
+		containerEl.empty();
+
+		containerEl.createEl("h2", { text: "Notion-Like Tables" });
+		// containerEl.createSpan(
+		// 	{},
+		// 	(span) =>
+		// 		(span.innerHTML = `<strong style="color: var(--text-accent); font-size: 12px;">Please restart Obsidian for these settings to take effect</strong>`)
+		// );
+
+		this.renderFileSettings(containerEl);
+		this.renderExportSettings(containerEl);
+		this.renderEmbeddedTableSettings(containerEl);
+		this.renderDebugSettings(containerEl);
 	}
 }

--- a/src/obsidian/nlt-settings-tab.ts
+++ b/src/obsidian/nlt-settings-tab.ts
@@ -16,7 +16,7 @@ export default class NLTSettingsTab extends PluginSettingTab {
 		//Attachments folder
 		const attachmentsFolderDesc = new DocumentFragment();
 		attachmentsFolderDesc.createSpan({}, (span) => {
-			span.innerHTML = `Create tables in the attachments folder defined in the Obsidian settings.<br><br>This can be changed in <span style="color: var(--text-accent);">Files & Links -> Default location for new attachments</span><br><br>Otherwise, the custom location below will be used.`;
+			span.innerHTML = `Create tables in the attachments folder defined in the Obsidian settings.<br><br>This can be changed in <span style="color: var(--text-accent);">Files & Links -> Default location for new attachments</span><br><br>Otherwise, the folder location below will be used.`;
 		});
 
 		new Setting(containerEl)
@@ -33,16 +33,16 @@ export default class NLTSettingsTab extends PluginSettingTab {
 				});
 			});
 
-		//Custom location
-		const customLocationDesc = new DocumentFragment();
-		customLocationDesc.createSpan({}, (span) => {
-			span.innerHTML = `The folder that new tables will be created in. Please don't include a slash at the beginning or end of the value.<br>e.g. <strong>myfolder/subdirectory</strong><br><br>Default location is the vault root folder, if not specified.`;
+		//Folder location
+		const defaultLocationDesc = new DocumentFragment();
+		defaultLocationDesc.createSpan({}, (span) => {
+			span.innerHTML = `Where newly created tables are placed. Please don't include a slash at the beginning or end of the value.<br>e.g. <strong>myfolder/subdirectory</strong><br><br>Default location is the vault root folder, if not specified.`;
 		});
 
 		if (this.plugin.settings.createAtObsidianAttachmentFolder === false) {
 			new Setting(containerEl)
-				.setName("Custom location for new tables")
-				.setDesc(customLocationDesc)
+				.setName("Default location for new tables")
+				.setDesc(defaultLocationDesc)
 				.addText((cb) => {
 					cb.setValue(
 						this.plugin.settings.customFolderForNewTables
@@ -52,27 +52,6 @@ export default class NLTSettingsTab extends PluginSettingTab {
 					});
 				});
 		}
-
-		//Active file name
-		const activeFileNameTimestampDesc = new DocumentFragment();
-		activeFileNameTimestampDesc.createSpan({}, (span) => {
-			span.innerHTML = `If a markdown file is open, the active file name and current timestamp will be used as the table name.<br>e.g. if <strong>Test.md</strong> is open, the table will be named <strong>Test-2023-04-14T13.12.59-06.00.table</strong><br><br>Otherwise, the default table file name will be used.<br>e.g <strong>Untitled.table</strong>`;
-		});
-
-		new Setting(containerEl)
-			.setName(
-				"Create table name based on active file name and timestamp"
-			)
-			.setDesc(activeFileNameTimestampDesc)
-			.addToggle((cb) => {
-				cb.setValue(
-					this.plugin.settings.nameWithActiveFileNameAndTimestamp
-				).onChange(async (value) => {
-					this.plugin.settings.nameWithActiveFileNameAndTimestamp =
-						value;
-					await this.plugin.saveSettings();
-				});
-			});
 	}
 
 	private renderExportSettings(containerEl: HTMLElement) {

--- a/src/obsidian/utils.ts
+++ b/src/obsidian/utils.ts
@@ -35,14 +35,20 @@ export const findEmbeddedTableFile = (embeddedLinkEl: HTMLElement) => {
 	return tableFile ?? null;
 };
 
-export const getEmbeddedTableWidth = (embeddedLinkEl: HTMLElement) => {
+export const getEmbeddedTableWidth = (
+	embeddedLinkEl: HTMLElement,
+	defaultWidth: string
+) => {
 	const width = embeddedLinkEl.getAttribute("width");
-	if (width === null || width === "1") return "100%";
+	if (width === null || width === "1") return defaultWidth;
 	return numToPx(width);
 };
 
-export const getEmbeddedTableHeight = (embeddedLinkEl: HTMLElement) => {
+export const getEmbeddedTableHeight = (
+	embeddedLinkEl: HTMLElement,
+	defaultHeight: string
+) => {
 	const height = embeddedLinkEl.getAttribute("height");
-	if (height === null || height === "1") return "340px"; //exactly 4 normal body rows
+	if (height === null || height === "1") return defaultHeight; //exactly 4 normal body rows
 	return numToPx(height);
 };

--- a/src/react/export-app/index.tsx
+++ b/src/react/export-app/index.tsx
@@ -25,7 +25,9 @@ export function ExportApp({ tableState, filePath }: Props) {
 	const [exportType, setExportType] = React.useState<ExportType>(
 		ExportType.UNSELECTED
 	);
-	const { exportRenderMarkdown } = useAppSelector((state) => state.global);
+	const { exportRenderMarkdown } = useAppSelector(
+		(state) => state.global.settings
+	);
 	const [renderMarkdown, setRenderMarkdown] =
 		React.useState<boolean>(exportRenderMarkdown);
 

--- a/src/redux/global/global-slice.ts
+++ b/src/redux/global/global-slice.ts
@@ -1,15 +1,14 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { DEFAULT_SETTINGS, NLTSettings } from "src/main";
 
 interface GlobalState {
+	settings: NLTSettings;
 	isDarkMode: boolean;
-	shouldDebug: boolean;
-	exportRenderMarkdown: boolean;
 }
 
 const initialState: GlobalState = {
+	settings: DEFAULT_SETTINGS,
 	isDarkMode: false,
-	shouldDebug: false,
-	exportRenderMarkdown: true,
 };
 
 //This is the global slice of the redux store.
@@ -21,15 +20,11 @@ const globalSlice = createSlice({
 		setDarkMode(state, action: PayloadAction<boolean>) {
 			state.isDarkMode = action.payload;
 		},
-		setDebugMode(state, action: PayloadAction<boolean>) {
-			state.shouldDebug = action.payload;
-		},
-		setExportRenderMarkdown(state, action: PayloadAction<boolean>) {
-			state.exportRenderMarkdown = action.payload;
+		setSettings(state, action: PayloadAction<NLTSettings>) {
+			state.settings = action.payload;
 		},
 	},
 });
 
-export const { setDarkMode, setDebugMode, setExportRenderMarkdown } =
-	globalSlice.actions;
+export const { setDarkMode, setSettings } = globalSlice.actions;
 export default globalSlice.reducer;

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -11,7 +11,7 @@ export const log =
 	};
 
 export const useLogger = () => {
-	const { shouldDebug } = useAppSelector((state) => state.global);
+	const { shouldDebug } = useAppSelector((state) => state.global.settings);
 
 	const logger = React.useCallback(
 		(message: string, args?: Record<string, any>) =>


### PR DESCRIPTION
This update will
- store all of the loaded `NLTSettings` into the Redux store. The settings are then available for all tables and classes, using the `store.get()` method. This avoids us having to make a static reference to the `NLTPlugin` class.
- add a default width and height for embedded tables into the settings
- remove the `activeFilenameWithTimestamp` settings. This is a setting that is should no longer needed with the embedding of table files.

