### PR TITLE
feat: add hide option to column

### DIFF
--- a/src/react/table-app/header-cell-edit/base-menu.tsx
+++ b/src/react/table-app/header-cell-edit/base-menu.tsx
@@ -27,6 +27,7 @@ interface Props {
 	onSubmenuChange: (value: SubmenuType) => void;
 	onWrapOverflowToggle: (columnId: string, value: boolean) => void;
 	onDeleteClick: () => void;
+	onHideClick: () => void;
 }
 
 export default function BaseMenu({
@@ -41,6 +42,7 @@ export default function BaseMenu({
 	onWrapOverflowToggle,
 	onDeleteClick,
 	onColumnNameChange,
+	onHideClick,
 }: Props) {
 	const lastKeyPressed = React.useRef<string | null>(null);
 	const inputRef = React.useRef<HTMLInputElement | null>(null);
@@ -106,15 +108,18 @@ export default function BaseMenu({
 				onClick={() => onSortClick(SortDir.DESC)}
 				isSelected={columnSortDir === SortDir.DESC}
 			/>
+			<Divider />
+			<MenuItem
+				lucideId="eye-off"
+				name="Hide"
+				onClick={() => onHideClick()}
+			/>
 			{canDeleteColumn && (
-				<>
-					<Divider />
-					<MenuItem
-						lucideId="trash"
-						name="Delete"
-						onClick={() => onDeleteClick()}
-					/>
-				</>
+				<MenuItem
+					lucideId="trash"
+					name="Delete"
+					onClick={() => onDeleteClick()}
+				/>
 			)}
 			{columnType !== CellType.EMBED && (
 				<>

--- a/src/react/table-app/header-cell-edit/index.tsx
+++ b/src/react/table-app/header-cell-edit/index.tsx
@@ -54,6 +54,7 @@ interface Props {
 	onHorizontalPaddingClick: (columnId: string, value: PaddingSize) => void;
 	onVerticalPaddingClick: (columnId: string, value: PaddingSize) => void;
 	onMenuClose: () => void;
+	onHideClick: (columnId: string) => void;
 }
 
 const HeaderMenu = React.forwardRef<HTMLDivElement, Props>(function HeaderMenu(
@@ -86,6 +87,7 @@ const HeaderMenu = React.forwardRef<HTMLDivElement, Props>(function HeaderMenu(
 		onNameChange,
 		onCurrencyChange,
 		onDateFormatChange,
+		onHideClick,
 	}: Props,
 	ref
 ) {
@@ -144,6 +146,12 @@ const HeaderMenu = React.forwardRef<HTMLDivElement, Props>(function HeaderMenu(
 		setSubmenu(null);
 	}
 
+	function handleHideClick() {
+		onHideClick(columnId);
+		onMenuClose();
+		setSubmenu(null);
+	}
+
 	function handleDeleteClick() {
 		onDeleteClick(columnId);
 		onMenuClose();
@@ -190,6 +198,7 @@ const HeaderMenu = React.forwardRef<HTMLDivElement, Props>(function HeaderMenu(
 						onSubmenuChange={setSubmenu}
 						onWrapOverflowToggle={onWrapOverflowToggle}
 						onDeleteClick={handleDeleteClick}
+						onHideClick={handleHideClick}
 					/>
 				)}
 				{submenu === SubmenuType.OPTIONS && (

--- a/src/react/table-app/header-cell/index.tsx
+++ b/src/react/table-app/header-cell/index.tsx
@@ -50,6 +50,7 @@ interface Props {
 	onVerticalPaddingClick: (columnId: string, value: PaddingSize) => void;
 	onHorizontalPaddingClick: (columnId: string, value: PaddingSize) => void;
 	onAspectRatioClick: (columnId: string, value: AspectRatio) => void;
+	onHideClick: (columnId: string) => void;
 }
 
 export default function HeaderCell({
@@ -79,6 +80,7 @@ export default function HeaderCell({
 	onNameChange,
 	onCurrencyChange,
 	onDateFormatChange,
+	onHideClick,
 }: Props) {
 	const { menu, isMenuOpen, closeTopMenu, menuRef, menuCloseRequest } =
 		useMenu(MenuLevel.ONE, { shouldRequestOnClose: true });
@@ -194,6 +196,7 @@ export default function HeaderCell({
 				onVerticalPaddingClick={onVerticalPaddingClick}
 				onHorizontalPaddingClick={onHorizontalPaddingClick}
 				onAspectRatioClick={onAspectRatioClick}
+				onHideClick={onHideClick}
 			/>
 		</>
 	);

--- a/src/react/table-app/index.tsx
+++ b/src/react/table-app/index.tsx
@@ -87,6 +87,7 @@ const TableApp = () => {
 		handleCurrencyChange,
 		handleDateFormatChange,
 		handleColumnDeleteClick,
+		handleColumnHideClick,
 		handleColumnSortClick,
 		handleColumnTypeClick,
 		handleColumnWidthChange,
@@ -374,6 +375,7 @@ const TableApp = () => {
 											onAspectRatioClick={
 												handleAspectRatioClick
 											}
+											onHideClick={handleColumnHideClick}
 										/>
 									),
 								};

--- a/src/shared/table-state/use-column.ts
+++ b/src/shared/table-state/use-column.ts
@@ -100,6 +100,15 @@ export const useColumn = () => {
 		[doCommand, logger]
 	);
 
+	function handleColumnHideClick(columnId: string) {
+		logger("handleColumnHideClick", {
+			columnId,
+		});
+		doCommand(
+			new ColumnUpdateCommand(columnId, "isVisible", { value: false })
+		);
+	}
+
 	function handleColumnDeleteClick(columnId: string) {
 		logger("handleColumnDeleteClick", {
 			columnId,
@@ -205,5 +214,6 @@ export const useColumn = () => {
 		handleHorizontalPaddingClick,
 		handleVerticalPaddingClick,
 		handleAspectRatioClick,
+		handleColumnHideClick,
 	};
 };


### PR DESCRIPTION
This update will add a hide option to the header cell edit base menu. It uses the same logic as the toggle menu for changing the visibility of a column.