### PR TITLE
fix: select tag on enter press

### DIFF
--- a/src/react/shared/menu-item/index.tsx
+++ b/src/react/shared/menu-item/index.tsx
@@ -47,9 +47,7 @@ export default function MenuItem({
 		if (e.key === "Enter") {
 			//Stop propagation so the the menu doesn't close when pressing enter
 			e.stopPropagation();
-
-			if (!onClick) return;
-			onClick();
+			onClick?.();
 		}
 	}
 

--- a/src/react/shared/tag/index.tsx
+++ b/src/react/shared/tag/index.tsx
@@ -1,20 +1,22 @@
+import { css } from "@emotion/react";
+
 import Icon from "../icon";
 import Stack from "../stack";
+import Button from "../button";
+import Padding from "../padding";
+
 import { Color } from "src/shared/types";
 import { findColorClassName } from "src/shared/color";
-import Button from "../button";
-
-import "./styles.css";
 import { useAppSelector } from "src/redux/global/hooks";
-import Padding from "../padding";
+
 interface Props {
 	id?: string;
 	maxWidth?: string;
 	markdown: string;
 	color: Color;
-	showRemove?: boolean;
-	onRemoveClick?: (tagId: string) => void;
-	onClick?: (tagId: string) => void;
+	showRemoveButton?: boolean;
+	onRemoveClick?: (id: string) => void;
+	onClick?: (id: string) => void;
 }
 
 export default function Tag({
@@ -22,7 +24,7 @@ export default function Tag({
 	color,
 	maxWidth,
 	markdown,
-	showRemove,
+	showRemoveButton,
 	onRemoveClick,
 }: Props) {
 	const { isDarkMode } = useAppSelector((state) => state.global);
@@ -41,7 +43,17 @@ export default function Tag({
 		contentClassName += " " + "NLT__hide-overflow-ellipsis";
 	}
 	return (
-		<div className={tagClass}>
+		<div
+			className={tagClass}
+			css={css`
+				display: flex;
+				align-items: center;
+				border-radius: 8px;
+				padding: var(--nlt-spacing--xs) var(--nlt-spacing--md);
+				width: max-content;
+				color: var(--text-normal);
+			`}
+		>
 			<Stack spacing="sm" justify="center">
 				<div
 					className={contentClassName}
@@ -49,14 +61,13 @@ export default function Tag({
 				>
 					{markdown}
 				</div>
-				{showRemove && (
+				{showRemoveButton && (
 					<Padding width="max-content">
 						<Button
 							isSmall
 							icon={<Icon lucideId="x" />}
 							onClick={() => {
-								onRemoveClick !== undefined &&
-									onRemoveClick(id!); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+								if (id && onRemoveClick) onRemoveClick(id);
 							}}
 						/>
 					</Padding>

--- a/src/react/shared/tag/styles.css
+++ b/src/react/shared/tag/styles.css
@@ -1,8 +1,0 @@
-.NLT__tag {
-    display: flex;
-    align-items: center;
-    border-radius: 8px;
-    padding: var(--nlt-spacing--xs) var(--nlt-spacing--md);
-    width: max-content;
-    color: var(--text-normal);
-}

--- a/src/react/table-app/styles.css
+++ b/src/react/table-app/styles.css
@@ -124,7 +124,7 @@
 }
 
 .NLT__selectable:hover {
-	background-color: var(--color-base-30)
+	background-color: var(--color-base-30);
 }
 
 .NLT__selected {
@@ -132,10 +132,20 @@
 }
 
 /**
- * Components
- */
+* Remove padding from the view container
+*/
 .workspace-leaf-content[data-type="notion-like-tables"] .view-content {
 	padding: 0;
+}
+
+/**
+* Obsidian automatically has a style applied to
+* button:not(.clickable-icon)
+* We want to override this for our butons
+*/
+.NLT__app button, .NLT__menu button {
+	background-color: unset;
+	box-shadow: unset;
 }
 
 .NLT__default-cursor {

--- a/src/react/table-app/tag-cell-edit/create-tag.tsx
+++ b/src/react/table-app/tag-cell-edit/create-tag.tsx
@@ -13,9 +13,9 @@ interface Props {
 
 export default function CreateTag({ markdown, color, onTagAdd }: Props) {
 	return (
-		<div
-			tabIndex={0}
+		<button
 			css={css`
+				all: unset; //reset button style
 				display: flex;
 				align-items: center;
 				padding: 4px 6px;
@@ -23,14 +23,12 @@ export default function CreateTag({ markdown, color, onTagAdd }: Props) {
 				overflow: hidden;
 			`}
 			className="NLT__focusable NLT__selectable"
-			onClick={() => {
-				onTagAdd(markdown, color);
-			}}
+			onClick={() => onTagAdd(markdown, color)}
 		>
 			<Stack spacing="sm">
 				<div>Create</div>
 				<Tag markdown={markdown} color={color} maxWidth="120px" />
 			</Stack>
-		</div>
+		</button>
 	);
 }

--- a/src/react/table-app/tag-cell-edit/index.tsx
+++ b/src/react/table-app/tag-cell-edit/index.tsx
@@ -53,10 +53,13 @@ export default function TagCellEdit({
 	React.useEffect(() => {
 		if (hasCloseRequestTimeChanged && menuCloseRequest !== null) {
 			if (menuCloseRequest.type === "enter") {
-				const shouldAddTag =
-					columnTags.find((tag) => tag.markdown === inputValue) ===
-					undefined;
-				if (shouldAddTag) handleTagAdd(inputValue, newTagColor);
+				const doesTagExist = columnTags.find(
+					(tag) => tag.markdown === inputValue
+				);
+				if (!doesTagExist) {
+					handleTagAdd(inputValue, newTagColor);
+					return;
+				}
 			}
 			onMenuClose();
 		}

--- a/src/react/table-app/tag-cell-edit/menu-body.tsx
+++ b/src/react/table-app/tag-cell-edit/menu-body.tsx
@@ -26,9 +26,8 @@ export default function MenuBody({
 	onTagColorChange,
 	onTagDelete,
 }: MenuBodyProps) {
-	const tagWithSameCase = columnTags.find(
-		(tag) => tag.markdown === inputValue
-	);
+	const hasTagWithSameCase =
+		columnTags.find((tag) => tag.markdown === inputValue) !== undefined;
 	const filteredTags = columnTags.filter((tag) =>
 		tag.markdown.toLowerCase().includes(inputValue.toLowerCase())
 	);
@@ -48,7 +47,7 @@ export default function MenuBody({
 					width: 100%;
 				`}
 			>
-				{tagWithSameCase === undefined && inputValue !== "" && (
+				{!hasTagWithSameCase && inputValue !== "" && (
 					<CreateTag
 						markdown={inputValue}
 						color={newTagColor}

--- a/src/react/table-app/tag-cell-edit/menu-header.tsx
+++ b/src/react/table-app/tag-cell-edit/menu-header.tsx
@@ -43,7 +43,7 @@ export default function MenuHeader({
 						color={tag.color}
 						markdown={tag.markdown}
 						maxWidth="150px"
-						showRemove
+						showRemoveButton
 						onRemoveClick={onRemoveTag}
 					/>
 				))}

--- a/src/react/table-app/tag-cell-edit/selectable-tag.tsx
+++ b/src/react/table-app/tag-cell-edit/selectable-tag.tsx
@@ -45,6 +45,23 @@ export default function SelectableTag({
 		closeTopMenu();
 	}
 
+	function handleKeyDown(e: React.KeyboardEvent) {
+		if (e.key === "Enter") {
+			//Stop propagation so the the menu doesn't remove the focus class
+			e.stopPropagation();
+			onClick(id);
+		}
+	}
+
+	function handleClick(e: React.MouseEvent) {
+		const target = e.target as HTMLElement;
+		if (target.classList.contains("NLT__menu-trigger")) return;
+
+		//Stop propagation so the the menu doesn't remove the focus class
+		e.stopPropagation();
+		onClick(id);
+	}
+
 	return (
 		<>
 			<div
@@ -58,14 +75,8 @@ export default function SelectableTag({
 					overflow: hidden;
 				`}
 				className="NLT__focusable NLT__selectable"
-				onClick={(e) => {
-					const target = e.target as HTMLElement;
-					if (target.classList.contains("NLT__menu-trigger")) return;
-
-					//Stop propagation so the the menu doesn't remove the focus class
-					e.stopPropagation();
-					onClick(id);
-				}}
+				onClick={handleClick}
+				onKeyDown={handleKeyDown}
 			>
 				<Tag markdown={markdown} color={color} maxWidth="150px" />
 				<MenuButton

--- a/src/shared/menu/menu-context.tsx
+++ b/src/shared/menu/menu-context.tsx
@@ -148,6 +148,7 @@ export default function MenuProvider({ children }: Props) {
 	 */
 	const requestCloseTopMenu = React.useCallback(
 		(type: MenuCloseRequestType) => {
+			logger("MenuProvider requestCloseTopMenu");
 			const menu = getTopMenu();
 			if (!menu) return;
 
@@ -162,7 +163,7 @@ export default function MenuProvider({ children }: Props) {
 
 			closeTopMenu();
 		},
-		[closeTopMenu, getTopMenu]
+		[closeTopMenu, getTopMenu, logger]
 	);
 
 	return (


### PR DESCRIPTION
When a tag is focused and has a focus indicator, it will now be selectable by pressing enter. 